### PR TITLE
CNTRLPLANE-1274: Add python directory in excluded list of snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,3 +5,4 @@ exclude:
   global:
     - vendor/**
     - "**/*_test.go"
+    - python/**


### PR DESCRIPTION
This directory is used for delivery of the binary. It is not directly related to the code base. It is better to fix it but for now we can add it in exclude list.