### PR TITLE
OLS-2024: Remove image expiration from the on-push Konflux pipeline

### DIFF
--- a/.tekton/openshift-mcp-server-push.yaml
+++ b/.tekton/openshift-mcp-server-push.yaml
@@ -28,8 +28,6 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server:{{revision}}
-    - name: image-expires-after
-      value: 5d
     - name: build-platforms
       value:
         - linux/x86_64


### PR DESCRIPTION
Remove image expiration from the on-push Konflux pipeline.
JIRA: https://issues.redhat.com/browse/OLS-2024