### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-mcp-server

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -27,11 +27,12 @@ ENV CONFIG_PATH=/mcp_config.toml
 
 # Labels for enterprise contract
 LABEL com.redhat.component=openshift-mcp-server
+LABEL cpe="cpe:/a:redhat:openshift_lightspeed:1::el9"
 LABEL description="Red Hat OpenShift MCP Server"
 LABEL io.k8s.description="Red Hat OpenShift MCP Server"
 LABEL io.k8s.display-name="Red Hat OpenShift MCP Server"
 LABEL io.openshift.tags="openshift,mcp"
-LABEL name=openshift-mcp-server
+LABEL name="openshift-lightspeed/openshift-mcp-server-rhel9"
 LABEL release=0.0.1
 LABEL url="https://github.com/openshift/openshift-mcp-server"
 LABEL vendor="Red Hat, Inc."


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
