### PR TITLE
Fix staticcheck lint errors

### DIFF
--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -436,7 +436,7 @@ func (s *BaseMcpSuite) SetupTest() {
 
 func (s *BaseMcpSuite) TearDownTest() {
 	if s.McpClient != nil {
-		s.McpClient.Close()
+		s.Close()
 	}
 	if s.mcpServer != nil {
 		s.mcpServer.Close()

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -48,16 +48,16 @@ func (c *Configuration) ListOutput() output.Output {
 }
 
 func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
-	if c.StaticConfig.ReadOnly && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) {
+	if c.ReadOnly && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) {
 		return false
 	}
-	if c.StaticConfig.DisableDestructive && ptr.Deref(tool.Tool.Annotations.DestructiveHint, false) {
+	if c.DisableDestructive && ptr.Deref(tool.Tool.Annotations.DestructiveHint, false) {
 		return false
 	}
-	if c.StaticConfig.EnabledTools != nil && !slices.Contains(c.StaticConfig.EnabledTools, tool.Tool.Name) {
+	if c.EnabledTools != nil && !slices.Contains(c.EnabledTools, tool.Tool.Name) {
 		return false
 	}
-	if c.StaticConfig.DisabledTools != nil && slices.Contains(c.StaticConfig.DisabledTools, tool.Tool.Name) {
+	if c.DisabledTools != nil && slices.Contains(c.DisabledTools, tool.Tool.Name) {
 		return false
 	}
 	return true
@@ -79,7 +79,7 @@ func NewServer(configuration Configuration) (*Server, error) {
 		server.WithLogging(),
 		server.WithToolHandlerMiddleware(toolCallLoggingMiddleware),
 	)
-	if configuration.StaticConfig.RequireOAuth && false { // TODO: Disabled scope auth validation for now
+	if configuration.RequireOAuth && false { // TODO: Disabled scope auth validation for now
 		serverOptions = append(serverOptions, server.WithToolHandlerMiddleware(toolScopedAuthorizationMiddleware))
 	}
 

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -29,7 +29,7 @@ func (s *ToolsetsSuite) SetupTest() {
 	s.originalToolsets = toolsets.Toolsets()
 	s.MockServer = test.NewMockServer()
 	s.Cfg = configuration.Default()
-	s.Cfg.KubeConfig = s.MockServer.KubeconfigFile(s.T())
+	s.Cfg.KubeConfig = s.KubeconfigFile(s.T())
 }
 
 func (s *ToolsetsSuite) TearDownTest() {

--- a/pkg/toolsets/core/namespaces.go
+++ b/pkg/toolsets/core/namespaces.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 )
 
@@ -52,7 +51,7 @@ func initNamespaces(o internalk8s.Openshift) []api.ServerTool {
 }
 
 func namespacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ret, err := params.NamespacesList(params, kubernetes.ResourceListOptions{AsTable: params.ListOutput.AsTable()})
+	ret, err := params.NamespacesList(params, internalk8s.ResourceListOptions{AsTable: params.ListOutput.AsTable()})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list namespaces: %v", err)), nil
 	}
@@ -60,7 +59,7 @@ func namespacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func projectsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ret, err := params.ProjectsList(params, kubernetes.ResourceListOptions{AsTable: params.ListOutput.AsTable()})
+	ret, err := params.ProjectsList(params, internalk8s.ResourceListOptions{AsTable: params.ListOutput.AsTable()})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list projects: %v", err)), nil
 	}

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 )
@@ -152,7 +151,7 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		namespace = ""
 	}
 	labelSelector := params.GetArguments()["labelSelector"]
-	resourceListOptions := kubernetes.ResourceListOptions{
+	resourceListOptions := internalk8s.ResourceListOptions{
 		AsTable: params.ListOutput.AsTable(),
 	}
 


### PR DESCRIPTION
## Summary
- Fix embedded field selector issues (QF1008) by removing redundant embedded field qualifiers
- Fix duplicate package imports (ST1019) by consolidating kubernetes package imports to use internalk8s alias consistently
- All tests pass successfully after changes

## Changes
- **pkg/mcp/common_test.go**: Remove `McpClient` qualifier from `Close()` call
- **pkg/mcp/mcp.go**: Remove `StaticConfig` qualifiers for `ReadOnly`, `DisableDestructive`, `EnabledTools`, `DisabledTools`, and `RequireOAuth` fields
- **pkg/mcp/toolsets_test.go**: Remove `MockServer` qualifier from `KubeconfigFile()` call
- **pkg/toolsets/core/namespaces.go**: Remove duplicate kubernetes import, use internalk8s alias exclusively
- **pkg/toolsets/core/resources.go**: Remove duplicate kubernetes import, use internalk8s alias exclusively

## Test plan
- [x] `make lint` passes with 0 issues
- [x] `make test` passes all tests
- [x] `go test -v ./pkg/mcp/...` passes all MCP tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)