### PR TITLE
OCPMCP-9: add acm cluster provider

### DIFF
--- a/pkg/kubernetes/provider_acm_hub.go
+++ b/pkg/kubernetes/provider_acm_hub.go
@@ -226,9 +226,11 @@ func (p *acmHubClusterProvider) IsOpenShift(ctx context.Context) bool {
 }
 
 func (p *acmHubClusterProvider) VerifyToken(ctx context.Context, target, token, audience string) (*authenticationv1api.UserInfo, []string, error) {
-	// use hub cluster for token verification regardless of target
-	// TODO(Cali0707): update this to work off the configured auth provider for the target
-	return p.hubManager.VerifyToken(ctx, token, audience)
+	manager, err := p.managerForCluster(target)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get manager for cluster '%s', unable to verify token", target)
+	}
+	return manager.VerifyToken(ctx, token, audience)
 }
 
 func (p *acmHubClusterProvider) GetDerivedKubernetes(ctx context.Context, target string) (*Kubernetes, error) {


### PR DESCRIPTION
This PR adds a cluster provider that uses ACM and the cluster proxy addon to communicate with all the clusters managed by the hub cluster. This allows users to configure the connection in two ways:
1. `acm-kubeconfig` - this uses a specified context from the users kubeconfig to connect to a remote hub cluster, and uses the route to the cluster proxy addon to connect to any managed clusters
2. `acm` - this assumes that the mcp server is deployed within the hub cluster, and uses the cluster proxy addon service (instead of route) to talk to managed clusters

An example configuration for the `acm-kubeconfig` strategy which verifies TLS is as follows:
```toml
# ACM config rules
cluster_provider_strategy = "acm-kubeconfig"
[cluster_provider_configs.acm-kubeconfig]
context_name = "acm"
cluster_proxy_addon_host = "<cluster proxy route>"
cluster_proxy_addon_ca_file = "openshift-ca.crt"
```

An example configuration for the `acm` strategy which does not verify TLS is as follows:
```toml
cluster_provider_strategy = "acm"
[cluster_provider_configs.acm-kubeconfig]
cluster_proxy_addon_host = "<cluster proxy route>"
cluster_proxy_addon_skip_tls_verify = true
```