### PR TITLE
NO-JIRA: Fix broken ci tests (update go version to 1.25)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
-# Switch to registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 when Go v1.24.10 >= available
-ARG BUILDER_IMAGE=quay.io/jacobsee/openshift-build:rhel-9-golang-1.25
+# Switch to registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 when Go >= v1.24.10 available
+ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25-1764620329
 ARG BASE_IMAGE=registry.ci.openshift.org/ocp/4.20:base-rhel9
 
 # Build the manager binary

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=registry.redhat.io/ubi9/go-toolset:1.24.4-1754467841
+ARG BUILDER_IMAGE=registry.redhat.io/ubi9/go-toolset:1.25-1764620329
 ARG BASE_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
 
 # Build the manager binary


### PR DESCRIPTION
fix broken CI tests |  with updated go v1.25 image.
Note:- once we have offcial image with go v1.24.10>= we need to switch back to official version.