### PR TITLE
NO-JIRA: updated the konflux task-buildah-remote-oci-ta job

### DIFF
--- a/.tekton/openshift-mcp-server-pull-request.yaml
+++ b/.tekton/openshift-mcp-server-pull-request.yaml
@@ -257,7 +257,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:4f348fa6e0b5d7f976ae6cbb75f4e93bc0be1188f074e39bcae3b5fd71796a3f
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:c9eb4f18a14f4fab96add0028759af7aac21e42a93d3e098a5461de641a06f7f
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-mcp-server-push.yaml
+++ b/.tekton/openshift-mcp-server-push.yaml
@@ -254,7 +254,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:4f348fa6e0b5d7f976ae6cbb75f4e93bc0be1188f074e39bcae3b5fd71796a3f
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:c9eb4f18a14f4fab96add0028759af7aac21e42a93d3e098a5461de641a06f7f
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
updated the konflux task-buildah-remote-oci-ta job to resolve EC failure