### PR TITLE
NE-2488: Add OpenShift router tools to NetworkEdge toolset

### DIFF
--- a/docs/openshift/NETEDGE.md
+++ b/docs/openshift/NETEDGE.md
@@ -1,0 +1,149 @@
+# Network Ingress&DNS (netedge) Toolset
+
+This document provides guidance on using the Network Ingress&DNS (formerly known as Network Edge) toolset with the Kubernetes MCP Server.
+
+## Available Tools
+
+The netedge toolset provides tools for monitoring and troubleshooting OpenShift network ingress and DNS components.
+
+### Router Tools
+
+Tools to inspect and monitor OpenShift router pods (HAProxy):
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `get_router_config` | Retrieve the current router's HAProxy configuration | `pod` (optional) - Router pod name |
+| `get_router_info` | Retrieve HAProxy runtime information from the router | `pod` (optional) - Router pod name |
+| `get_router_sessions` | Retrieve all active sessions from the router | `pod` (optional) - Router pod name |
+
+### DNS Tools
+
+Tools to inspect and monitor CoreDNS configuration:
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `get_coredns_config` | Retrieve the current CoreDNS configuration (Corefile) | None |
+
+**Notes**:
+- Router tools have an optional `pod` parameter. If not provided, they automatically select any available router pod from the default ingress controller.
+- Currently, the default ingress controller name (`default`) is hard-coded. Support for custom ingress controller names may be added in future versions.
+
+## Examples
+
+### View Router Configuration
+
+View the router configuration file from any router pod:
+
+```text
+Show me the router configuration
+
+● I'll get the router configuration for you.
+  ⎿  # Router configuration (pod: router-default-6fbcf6cb84-vqthh)
+     ```
+     global
+     … +333 lines (ctrl+o to expand)
+
+● Here's the router configuration from pod router-default-6fbcf6cb84-vqthh. This is an HAProxy configuration for the OpenShift router with the following key settings:
+
+  Global Settings:
+  - Max connections: 50,000
+  - 4 worker threads
+  - TLS: Minimum version TLSv1.2
+  - Cipher suites: Modern secure ciphers (ECDHE-ECDSA, ECDHE-RSA, etc.)
+  - DH parameter size: 2048 bits
+
+  Timeout Settings:
+  - Connect: 5s
+  - Client/Server: 30s
+  - HTTP request: 10s
+  - HTTP keep-alive: 300s
+  - WebSocket tunnel: 1h
+  - Console: 5 minutes
+```
+
+Or specify a particular router pod:
+
+```text
+Show me the router configuration from pod router-default-6fbcf6cb84-vqthh
+```
+
+### View Router Runtime Information
+
+Get router runtime statistics and information:
+
+```text
+Show me the router info
+  ⎿  # Router HAProxy info (pod: router-default-6fbcf6cb84-vqthh)
+     ```
+     Name: HAProxy
+     … +76 lines (ctrl+o to expand)
+
+● Here's the HAProxy runtime information for the router (pod: router-default-6fbcf6cb84-vqthh):
+
+  Version Information:
+  - HAProxy Version: 2.8.10-f28885f
+  - Release Date: 2024/06/14
+  - Uptime: 1h 45m 7s
+
+  Process Information:
+  - PID: 138
+  - Threads: 4
+  - Processes: 1
+
+  Connection Statistics:
+  - Current Connections: 10
+  - Max Connections: 50,000
+  - Cumulative Connections: 2,253
+  - Cumulative Requests: 4,668
+  - Max Connection Rate: 12/sec
+
+  SSL/TLS Statistics:
+  - Current SSL Connections: 1
+  - Cumulative SSL Connections: 862
+  - SSL Frontend Max Key Rate: 4/sec
+  - SSL Backend Max Key Rate: 1/sec
+```
+
+This displays:
+- Router version and uptime
+- Process information
+- Connection statistics
+- Request rates
+- Memory usage
+
+### View Active Sessions
+
+View all active sessions in the router:
+
+```text
+Show me active router sessions
+  ⎿  # Router active sessions (pod: router-default-6fbcf6cb84-vqthh)
+     ```
+     0x7f223405ae50: [12/Jan/2026:22:35:39.393119] id=4697 proto=unix_stream source=unix:1
+     … +17 lines (ctrl+o to expand)
+
+● Here are the active sessions in the router (pod: router-default-6fbcf6cb84-vqthh):
+
+  There is currently 1 active session:
+
+  Session ID 4697 (CLI Connection)
+  - Protocol: Unix stream socket
+  - Frontend: GLOBAL (HAProxy admin socket)
+  - State: ESTABLISHED
+  - Age: 0s (just created)
+  - Type: CLI applet connection
+
+  Details:
+  - Connection flags: 0x8
+  - Task state: running with high priority (nice=-64)
+  - File descriptor: 23
+  - Buffers: 32KB request/response buffers allocated
+  - Request data: 14 bytes total (the command itself)
+  - Timeouts: 2 minutes for client, no write timeout
+```
+
+This displays detailed information about each active connection including:
+- Session ID and protocol
+- Connection state
+- Frontend and backend information
+- Task and file descriptor details

--- a/evals/tasks/netedge/get-router-config/task.yaml
+++ b/evals/tasks/netedge/get-router-config/task.yaml
@@ -1,0 +1,12 @@
+kind: Task
+metadata:
+  name: get-router-config
+steps:
+  verify:
+    contains: "frontend public"
+  prompt:
+    inline: Retrieve and display the current HAProxy configuration from the OpenShift router.
+  assertions:
+    toolsUsed:
+      - server: kubernetes
+        toolPattern: "netedge__get_router_config"

--- a/evals/tasks/netedge/get-router-config/task.yaml
+++ b/evals/tasks/netedge/get-router-config/task.yaml
@@ -9,4 +9,4 @@ steps:
   assertions:
     toolsUsed:
       - server: kubernetes
-        toolPattern: "netedge__get_router_config"
+        toolPattern: "get_router_config"

--- a/evals/tasks/netedge/get-router-info/task.yaml
+++ b/evals/tasks/netedge/get-router-info/task.yaml
@@ -1,0 +1,12 @@
+kind: Task
+metadata:
+  name: get-router-info
+steps:
+  verify:
+    contains: "Name: HAProxy"
+  prompt:
+    inline: Retrieve and display HAProxy runtime information and statistics from the OpenShift router.
+  assertions:
+    toolsUsed:
+      - server: kubernetes
+        toolPattern: "netedge__get_router_info"

--- a/evals/tasks/netedge/get-router-info/task.yaml
+++ b/evals/tasks/netedge/get-router-info/task.yaml
@@ -9,4 +9,4 @@ steps:
   assertions:
     toolsUsed:
       - server: kubernetes
-        toolPattern: "netedge__get_router_info"
+        toolPattern: "get_router_info"

--- a/evals/tasks/netedge/get-router-sessions/task.yaml
+++ b/evals/tasks/netedge/get-router-sessions/task.yaml
@@ -1,0 +1,12 @@
+kind: Task
+metadata:
+  name: get-router-sessions
+steps:
+  verify:
+    contains: "frontend=GLOBAL"
+  prompt:
+    inline: Retrieve and display all active sessions from the OpenShift router.
+  assertions:
+    toolsUsed:
+      - server: kubernetes
+        toolPattern: "netedge__get_router_sessions"

--- a/evals/tasks/netedge/get-router-sessions/task.yaml
+++ b/evals/tasks/netedge/get-router-sessions/task.yaml
@@ -9,4 +9,4 @@ steps:
   assertions:
     toolsUsed:
       - server: kubernetes
-        toolPattern: "netedge__get_router_sessions"
+        toolPattern: "get_router_sessions"

--- a/evals/tasks/netedge/query_prometheus/task.yaml
+++ b/evals/tasks/netedge/query_prometheus/task.yaml
@@ -9,6 +9,6 @@ steps:
   assertions:
     toolsUsed:
       - server: kubernetes
-        toolPattern: "netedge__query_prometheus"
+        toolPattern: "query_prometheus"
         args:
           diagnostic_target: "ingress"

--- a/pkg/toolsets/netedge/router.go
+++ b/pkg/toolsets/netedge/router.go
@@ -102,93 +102,93 @@ func initRouter() []api.ServerTool {
 // getRouterConfig requires a live cluster as it reads the HAProxy configuration
 // from a running router pod via exec. It cannot work against offline data (must-gather).
 func getRouterConfig(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	var results []string
+        var results []string
 
-	pod, ok := params.GetArguments()["pod"].(string)
-	if !ok || pod == "" {
-		p, err := getAnyRouterPod(params, defaultIngressControllerName)
-		if err != nil {
-			results = append(results, "# Router configuration")
-			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
-			return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
-		}
-		pod = p
-	}
+        pod, ok := params.GetArguments()["pod"].(string)
+        if !ok || pod == "" {
+                p, err := getAnyRouterPod(params, defaultIngressControllerName)
+                if err != nil {
+                        results = append(results, "# Router configuration")
+                        results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+                        return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+                }
+                pod = p
+        }
 
-	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"cat", "/var/lib/haproxy/conf/haproxy.config"})
-	if err != nil {
-		results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
-		results = append(results, fmt.Sprintf("Error showing router configuration from pod %q: %v", pod, err))
-	} else {
-		results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
-		results = append(results, "```")
-		results = append(results, out)
-		results = append(results, "```")
-	}
+        out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"cat", "/var/lib/haproxy/conf/haproxy.config"})
+        if err != nil {
+                results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
+                results = append(results, fmt.Sprintf("Error showing router configuration from pod %q: %v", pod, err))
+                return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+        }
 
-	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+        results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
+        results = append(results, "```")
+        results = append(results, out)
+        results = append(results, "```")
+
+        return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
 }
-
 // getRouterInfo requires a live cluster as it queries the HAProxy admin socket
 // via exec on a running router pod. It cannot work against offline data (must-gather).
 func getRouterInfo(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	var results []string
+        var results []string
 
-	pod, ok := params.GetArguments()["pod"].(string)
-	if !ok || pod == "" {
-		p, err := getAnyRouterPod(params, defaultIngressControllerName)
-		if err != nil {
-			results = append(results, "# Router HAProxy info")
-			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
-			return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
-		}
-		pod = p
-	}
+        pod, ok := params.GetArguments()["pod"].(string)
+        if !ok || pod == "" {
+                p, err := getAnyRouterPod(params, defaultIngressControllerName)
+                if err != nil {
+                        results = append(results, "# Router HAProxy info")
+                        results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+                        return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+                }
+                pod = p
+        }
 
-	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show info' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
-	if err != nil {
-		results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
-		results = append(results, fmt.Sprintf("Error getting HAProxy info from pod %q: %v", pod, err))
-	} else {
-		results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
-		results = append(results, "```")
-		results = append(results, out)
-		results = append(results, "```")
-	}
+        out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show info' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
+        if err != nil {
+                results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
+                results = append(results, fmt.Sprintf("Error getting HAProxy info from pod %q: %v", pod, err))
+                return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+        }
 
-	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+        results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
+        results = append(results, "```")
+        results = append(results, out)
+        results = append(results, "```")
+
+        return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
 }
-
 // getRouterSessions requires a live cluster as it queries the HAProxy admin socket
 // via exec on a running router pod. It cannot work against offline data (must-gather).
 func getRouterSessions(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	var results []string
+        var results []string
 
-	pod, ok := params.GetArguments()["pod"].(string)
-	if !ok || pod == "" {
-		p, err := getAnyRouterPod(params, defaultIngressControllerName)
-		if err != nil {
-			results = append(results, "# Router active sessions")
-			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
-			return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
-		}
-		pod = p
-	}
+        pod, ok := params.GetArguments()["pod"].(string)
+        if !ok || pod == "" {
+                p, err := getAnyRouterPod(params, defaultIngressControllerName)
+                if err != nil {
+                        results = append(results, "# Router active sessions")
+                        results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+                        return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+                }
+                pod = p
+        }
 
-	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show sess all' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
-	if err != nil {
-		results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
-		results = append(results, fmt.Sprintf("Error getting active sessions from pod %q: %v", pod, err))
-	} else {
-		results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
-		results = append(results, "```")
-		results = append(results, out)
-		results = append(results, "```")
-	}
+        out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show sess all' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
+        if err != nil {
+                results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
+                results = append(results, fmt.Sprintf("Error getting active sessions from pod %q: %v", pod, err))
+                return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+        }
 
-	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+        results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
+        results = append(results, "```")
+        results = append(results, out)
+        results = append(results, "```")
+
+        return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
 }
-
 func getAnyRouterPod(params api.ToolHandlerParams, icName string) (string, error) {
 	pods, err := params.DynamicClient().Resource(podGVR).Namespace(ingressNamespace).List(params.Context, metav1.ListOptions{
 		LabelSelector: "ingresscontroller.operator.openshift.io/deployment-ingresscontroller=" + icName,

--- a/pkg/toolsets/netedge/router.go
+++ b/pkg/toolsets/netedge/router.go
@@ -102,92 +102,94 @@ func initRouter() []api.ServerTool {
 // getRouterConfig requires a live cluster as it reads the HAProxy configuration
 // from a running router pod via exec. It cannot work against offline data (must-gather).
 func getRouterConfig(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-        var results []string
+	var results []string
 
-        pod, ok := params.GetArguments()["pod"].(string)
-        if !ok || pod == "" {
-                p, err := getAnyRouterPod(params, defaultIngressControllerName)
-                if err != nil {
-                        results = append(results, "# Router configuration")
-                        results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
-                        return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
-                }
-                pod = p
-        }
+	pod, ok := params.GetArguments()["pod"].(string)
+	if !ok || pod == "" {
+		p, err := getAnyRouterPod(params, defaultIngressControllerName)
+		if err != nil {
+			results = append(results, "# Router configuration")
+			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+			return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+		}
+		pod = p
+	}
 
-        out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"cat", "/var/lib/haproxy/conf/haproxy.config"})
-        if err != nil {
-                results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
-                results = append(results, fmt.Sprintf("Error showing router configuration from pod %q: %v", pod, err))
-                return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
-        }
+	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"cat", "/var/lib/haproxy/conf/haproxy.config"})
+	if err != nil {
+		results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
+		results = append(results, fmt.Sprintf("Error showing router configuration from pod %q: %v", pod, err))
+		return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+	}
 
-        results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
-        results = append(results, "```")
-        results = append(results, out)
-        results = append(results, "```")
+	results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
+	results = append(results, "```")
+	results = append(results, out)
+	results = append(results, "```")
 
-        return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
 }
+
 // getRouterInfo requires a live cluster as it queries the HAProxy admin socket
 // via exec on a running router pod. It cannot work against offline data (must-gather).
 func getRouterInfo(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-        var results []string
+	var results []string
 
-        pod, ok := params.GetArguments()["pod"].(string)
-        if !ok || pod == "" {
-                p, err := getAnyRouterPod(params, defaultIngressControllerName)
-                if err != nil {
-                        results = append(results, "# Router HAProxy info")
-                        results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
-                        return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
-                }
-                pod = p
-        }
+	pod, ok := params.GetArguments()["pod"].(string)
+	if !ok || pod == "" {
+		p, err := getAnyRouterPod(params, defaultIngressControllerName)
+		if err != nil {
+			results = append(results, "# Router HAProxy info")
+			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+			return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+		}
+		pod = p
+	}
 
-        out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show info' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
-        if err != nil {
-                results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
-                results = append(results, fmt.Sprintf("Error getting HAProxy info from pod %q: %v", pod, err))
-                return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
-        }
+	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show info' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
+	if err != nil {
+		results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
+		results = append(results, fmt.Sprintf("Error getting HAProxy info from pod %q: %v", pod, err))
+		return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+	}
 
-        results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
-        results = append(results, "```")
-        results = append(results, out)
-        results = append(results, "```")
+	results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
+	results = append(results, "```")
+	results = append(results, out)
+	results = append(results, "```")
 
-        return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
 }
+
 // getRouterSessions requires a live cluster as it queries the HAProxy admin socket
 // via exec on a running router pod. It cannot work against offline data (must-gather).
 func getRouterSessions(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-        var results []string
+	var results []string
 
-        pod, ok := params.GetArguments()["pod"].(string)
-        if !ok || pod == "" {
-                p, err := getAnyRouterPod(params, defaultIngressControllerName)
-                if err != nil {
-                        results = append(results, "# Router active sessions")
-                        results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
-                        return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
-                }
-                pod = p
-        }
+	pod, ok := params.GetArguments()["pod"].(string)
+	if !ok || pod == "" {
+		p, err := getAnyRouterPod(params, defaultIngressControllerName)
+		if err != nil {
+			results = append(results, "# Router active sessions")
+			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+			return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+		}
+		pod = p
+	}
 
-        out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show sess all' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
-        if err != nil {
-                results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
-                results = append(results, fmt.Sprintf("Error getting active sessions from pod %q: %v", pod, err))
-                return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
-        }
+	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show sess all' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
+	if err != nil {
+		results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
+		results = append(results, fmt.Sprintf("Error getting active sessions from pod %q: %v", pod, err))
+		return api.NewToolCallResult(strings.Join(results, "\n"), err), nil
+	}
 
-        results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
-        results = append(results, "```")
-        results = append(results, out)
-        results = append(results, "```")
+	results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
+	results = append(results, "```")
+	results = append(results, out)
+	results = append(results, "```")
 
-        return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
 }
 func getAnyRouterPod(params api.ToolHandlerParams, icName string) (string, error) {
 	pods, err := params.DynamicClient().Resource(podGVR).Namespace(ingressNamespace).List(params.Context, metav1.ListOptions{

--- a/pkg/toolsets/netedge/router.go
+++ b/pkg/toolsets/netedge/router.go
@@ -1,0 +1,204 @@
+package netedge
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+const (
+	ingressNamespace             = "openshift-ingress"
+	defaultIngressControllerName = "default"
+	routerContainerName          = "router"
+)
+
+var (
+	podGVR = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
+)
+
+func initRouter() []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "get_router_config",
+				Description: `Retrieve the current router's HAProxy configuration from the cluster.`,
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"pod": {
+							Type:        "string",
+							Description: "Router pod name (optional, chooses any existing if not provided)",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Get Router Config",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: getRouterConfig,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "get_router_info",
+				Description: `Retrieve HAProxy runtime information from the router.`,
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"pod": {
+							Type:        "string",
+							Description: "Router pod name (optional, chooses any existing if not provided)",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Get Router Info",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: getRouterInfo,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "get_router_sessions",
+				Description: `Retrieve all active sessions from the router.`,
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"pod": {
+							Type:        "string",
+							Description: "Router pod name (optional, chooses any existing if not provided)",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Get Router Sessions",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: getRouterSessions,
+		},
+	}
+}
+
+// getRouterConfig requires a live cluster as it reads the HAProxy configuration
+// from a running router pod via exec. It cannot work against offline data (must-gather).
+func getRouterConfig(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	var results []string
+
+	pod, ok := params.GetArguments()["pod"].(string)
+	if !ok || pod == "" {
+		p, err := getAnyRouterPod(params, defaultIngressControllerName)
+		if err != nil {
+			results = append(results, "# Router configuration")
+			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+			return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+		}
+		pod = p
+	}
+
+	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"cat", "/var/lib/haproxy/conf/haproxy.config"})
+	if err != nil {
+		results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
+		results = append(results, fmt.Sprintf("Error showing router configuration from pod %q: %v", pod, err))
+	} else {
+		results = append(results, fmt.Sprintf("# Router configuration (pod: %s)", pod))
+		results = append(results, "```")
+		results = append(results, out)
+		results = append(results, "```")
+	}
+
+	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+}
+
+// getRouterInfo requires a live cluster as it queries the HAProxy admin socket
+// via exec on a running router pod. It cannot work against offline data (must-gather).
+func getRouterInfo(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	var results []string
+
+	pod, ok := params.GetArguments()["pod"].(string)
+	if !ok || pod == "" {
+		p, err := getAnyRouterPod(params, defaultIngressControllerName)
+		if err != nil {
+			results = append(results, "# Router HAProxy info")
+			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+			return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+		}
+		pod = p
+	}
+
+	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show info' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
+	if err != nil {
+		results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
+		results = append(results, fmt.Sprintf("Error getting HAProxy info from pod %q: %v", pod, err))
+	} else {
+		results = append(results, fmt.Sprintf("# Router HAProxy info (pod: %s)", pod))
+		results = append(results, "```")
+		results = append(results, out)
+		results = append(results, "```")
+	}
+
+	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+}
+
+// getRouterSessions requires a live cluster as it queries the HAProxy admin socket
+// via exec on a running router pod. It cannot work against offline data (must-gather).
+func getRouterSessions(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	var results []string
+
+	pod, ok := params.GetArguments()["pod"].(string)
+	if !ok || pod == "" {
+		p, err := getAnyRouterPod(params, defaultIngressControllerName)
+		if err != nil {
+			results = append(results, "# Router active sessions")
+			results = append(results, fmt.Sprintf("Error getting router pod: %v", err))
+			return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+		}
+		pod = p
+	}
+
+	out, err := kubernetes.NewCore(params).PodsExec(params.Context, ingressNamespace, pod, routerContainerName, []string{"sh", "-c", "echo 'show sess all' | socat stdio /var/lib/haproxy/run/haproxy.sock"})
+	if err != nil {
+		results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
+		results = append(results, fmt.Sprintf("Error getting active sessions from pod %q: %v", pod, err))
+	} else {
+		results = append(results, fmt.Sprintf("# Router active sessions (pod: %s)", pod))
+		results = append(results, "```")
+		results = append(results, out)
+		results = append(results, "```")
+	}
+
+	return api.NewToolCallResult(strings.Join(results, "\n"), nil), nil
+}
+
+func getAnyRouterPod(params api.ToolHandlerParams, icName string) (string, error) {
+	pods, err := params.DynamicClient().Resource(podGVR).Namespace(ingressNamespace).List(params.Context, metav1.ListOptions{
+		LabelSelector: "ingresscontroller.operator.openshift.io/deployment-ingresscontroller=" + icName,
+		FieldSelector: "status.phase=Running",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list router pods: %v", err)
+	}
+	for _, pod := range pods.Items {
+		return pod.GetName(), nil
+	}
+	return "", errors.New("no running router pod found")
+}

--- a/pkg/toolsets/netedge/toolset.go
+++ b/pkg/toolsets/netedge/toolset.go
@@ -29,9 +29,9 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 		initProbeDNSLocal(),
 		initProbeHTTP(),
 		initRoutes(),
-                initExecDNSInPod(),
-                initRouter(),
-                )
+		initExecDNSInPod(),
+		initRouter(),
+	)
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {

--- a/pkg/toolsets/netedge/toolset.go
+++ b/pkg/toolsets/netedge/toolset.go
@@ -29,8 +29,9 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 		initProbeDNSLocal(),
 		initProbeHTTP(),
 		initRoutes(),
-		initExecDNSInPod(),
-	)
+                initExecDNSInPod(),
+                initRouter(),
+                )
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {


### PR DESCRIPTION
This PR introduces new tools for inspecting OpenShift router pods through the Kubernetes MCP Server.

Added tools:
- `get_router_config`: View the router's configuration
- `get_router_info`: Get router runtime information and statistics
- `get_router_sessions`: View all active sessions in the router

Documentation: Added `NETEDGE.md` covering the NetworkEdge toolset, including both router and CoreDNS tools.

Tests: Added evaluation tasks for the added tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Network Ingress & DNS (netedge) toolset with three OpenShift router inspection tools to retrieve HAProxy config, runtime info, and active sessions; each accepts an optional pod parameter and auto-selects a running router pod when omitted.

* **Documentation**
  * New guide describing the netedge toolset, parameters, behavior, usage examples, and CoreDNS retrieval.

* **Tests**
  * Added evaluation tasks validating each router inspection tool and adjusted a prometheus query task assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->