### PR TITLE
OLS-2492: Have Konflux apply the 'latest' floating tag to the images it builds.

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -38,5 +38,6 @@ LABEL url="https://github.com/openshift/openshift-mcp-server"
 LABEL vendor="Red Hat, Inc."
 LABEL version=0.0.1
 LABEL summary="Red Hat OpenShift MCP Server"
+LABEL konflux.additional-tags="latest"
 
 ENTRYPOINT ["/openshift-mcp-server", "--config", "$CONFIG_PATH"]


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OLS-2492