### PR TITLE
OCPSTRAT-2794: Add OADP toolset for managing Velero backups and restores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ python/build/
 python/dist/
 python/kubernetes_mcp_server.egg-info/
 !python/kubernetes-mcp-server
+.notes/

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,29 @@ local-env-setup-tekton: ## Setup complete local development environment with Kin
 	@echo "Tekton Pipelines is now available!"
 	@echo "Check status with: make tekton-status"
 
+.PHONY: local-env-setup-oadp
+local-env-setup-oadp: ## Setup complete local development environment with Kind cluster and OADP/Velero
+	@echo "========================================="
+	@echo "Kubernetes MCP Server - Local Setup"
+	@echo "          with OADP / Velero"
+	@echo "========================================="
+	$(MAKE) kind-create-cluster
+	$(MAKE) oadp-install
+	$(MAKE) build
+	@echo ""
+	@echo "========================================="
+	@echo "Local environment ready!"
+	@echo "========================================="
+	@echo ""
+	@echo "Run the MCP server with:"
+	@echo "  ./$(BINARY_NAME) --toolsets core,config,oadp"
+	@echo ""
+	@echo "Or run with MCP inspector:"
+	@echo "  npx @modelcontextprotocol/inspector@latest $$(pwd)/$(BINARY_NAME) --toolsets core,config,oadp"
+	@echo ""
+	@echo "OADP / Velero is now available!"
+	@echo "Check status with: make oadp-status"
+
 .PHONY: local-env-teardown
 local-env-teardown: ## Tear down the local Kind cluster
 	$(MAKE) kind-delete-cluster

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ The following sets of tools are available (toolsets marked with ✓ in the Defau
 | kcp      | Manage kcp workspaces and multi-tenancy features                                                                                                                                |         |
 | kubevirt | KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details. |         |
 | metrics  | Toolset for querying Prometheus and Alertmanager endpoints in efficient ways.                                                                                                   |         |
+| oadp     | OADP (OpenShift API for Data Protection) tools for managing Velero backups, restores, and schedules                                                                             |         |
 | ossm     | Most common tools for managing OSSM, check the [OSSM documentation](https://github.com/openshift/openshift-mcp-server/blob/main/docs/OSSM.md) for more details.                 |         |
 | tekton   | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, and TaskRuns.                                                                                              |         |
 | traces   | Toolset for querying Tempo                                                                                                                                                      |         |
@@ -861,6 +862,17 @@ Use tempo_search_tags to discover available tag names.
 - **vm-troubleshoot** - Generate a step-by-step troubleshooting guide for diagnosing KubeVirt VirtualMachine issues
   - `namespace` (`string`) **(required)** - The namespace of the VirtualMachine to troubleshoot
   - `name` (`string`) **(required)** - The name of the VirtualMachine to troubleshoot
+
+</details>
+
+<details>
+
+<summary>oadp</summary>
+
+- **oadp-troubleshoot** - Generate a step-by-step troubleshooting guide for diagnosing OADP backup and restore issues
+  - `namespace` (`string`) - The OADP namespace (default: openshift-adp)
+  - `backup` (`string`) - The name of a specific backup to troubleshoot
+  - `restore` (`string`) - The name of a specific restore to troubleshoot
 
 </details>
 

--- a/build/oadp.mk
+++ b/build/oadp.mk
@@ -1,0 +1,224 @@
+# OADP / Velero installation for local development and evals
+#
+# Installs Velero with MinIO as the object storage backend in the openshift-adp
+# namespace. Also applies the OADP CRDs (DPA, DataProtectionTest) and creates a
+# sample DataProtectionApplication so that all OADP evals can run on a Kind cluster.
+
+VELERO_VERSION ?= v1.16.2
+VELERO_PLUGIN_AWS_VERSION ?= v1.12.2
+VELERO_CLI = $(shell pwd)/_output/tools/bin/velero
+VELERO_OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+VELERO_ARCH = $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+OADP_NAMESPACE = openshift-adp
+
+VELERO_RELEASE_URL = https://github.com/vmware-tanzu/velero/releases/download/$(VELERO_VERSION)
+OADP_CRD_BASE_URL = https://raw.githubusercontent.com/openshift/oadp-operator/oadp-1.5/config/crd/bases
+
+define MINIO_DEPLOYMENT
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: $(OADP_NAMESPACE)
+  name: minio
+  labels:
+    component: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      component: minio
+  template:
+    metadata:
+      labels:
+        component: minio
+    spec:
+      volumes:
+      - name: storage
+        emptyDir: {}
+      containers:
+      - name: minio
+        image: quay.io/minio/minio:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - server
+        - /storage
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - name: storage
+          mountPath: "/storage"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: $(OADP_NAMESPACE)
+  name: minio
+  labels:
+    component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    component: minio
+endef
+export MINIO_DEPLOYMENT
+
+define SAMPLE_DPA
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: velero-sample
+  namespace: $(OADP_NAMESPACE)
+spec:
+  configuration:
+    velero:
+      defaultPlugins:
+        - aws
+  backupLocations:
+    - velero:
+        provider: aws
+        default: true
+        objectStorage:
+          bucket: velero
+        config:
+          region: minio
+          s3ForcePathStyle: "true"
+          s3Url: http://minio.$(OADP_NAMESPACE).svc:9000
+        credential:
+          name: cloud-credentials
+          key: cloud
+endef
+export SAMPLE_DPA
+
+##@ OADP / Velero
+
+.PHONY: velero-cli
+velero-cli: ## Download the Velero CLI
+	@if [ -f $(VELERO_CLI) ]; then \
+		echo "Velero CLI already installed at $(VELERO_CLI)"; \
+	else \
+		set -e; \
+		echo "Downloading Velero CLI $(VELERO_VERSION)..."; \
+		mkdir -p $(shell dirname $(VELERO_CLI)); \
+		TMPDIR=$$(mktemp -d); \
+		curl -fsSL $(VELERO_RELEASE_URL)/velero-$(VELERO_VERSION)-$(VELERO_OS)-$(VELERO_ARCH).tar.gz -o $$TMPDIR/velero.tar.gz; \
+		tar -xzf $$TMPDIR/velero.tar.gz -C $$TMPDIR; \
+		cp $$TMPDIR/velero-$(VELERO_VERSION)-$(VELERO_OS)-$(VELERO_ARCH)/velero $(VELERO_CLI); \
+		chmod +x $(VELERO_CLI); \
+		rm -rf $$TMPDIR; \
+		echo "Velero CLI installed at $(VELERO_CLI)"; \
+	fi
+
+.PHONY: oadp-install
+oadp-install: velero-cli ## Install Velero + MinIO for OADP eval testing
+	@echo "========================================="
+	@echo "Installing Velero $(VELERO_VERSION) with MinIO"
+	@echo "for OADP eval testing"
+	@echo "========================================="
+	@echo ""
+	@echo "Creating namespace $(OADP_NAMESPACE)..."
+	@kubectl create namespace $(OADP_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	@echo ""
+	@echo "Deploying MinIO..."
+	@echo "$$MINIO_DEPLOYMENT" | kubectl apply -f -
+	@echo ""
+	@echo "Waiting for MinIO to be ready..."
+	@kubectl wait --for=condition=available deployment/minio -n $(OADP_NAMESPACE) --timeout=5m
+	@echo "✅ MinIO is ready"
+	@echo ""
+	@echo "Creating MinIO bucket..."
+	@kubectl run minio-bucket-setup --rm -i --restart=Never --namespace $(OADP_NAMESPACE) \
+		--image=quay.io/minio/mc:latest --command -- sh -c \
+		"mc alias set velero http://minio:9000 minio minio123 && mc mb -p velero/velero"
+	@echo "✅ MinIO bucket created"
+	@echo ""
+	@echo "Installing Velero..."
+	@CRED_FILE=$$(mktemp); \
+	printf '[default]\naws_access_key_id = minio\naws_secret_access_key = minio123\n' > $$CRED_FILE; \
+	$(VELERO_CLI) install \
+		--provider aws \
+		--plugins velero/velero-plugin-for-aws:$(VELERO_PLUGIN_AWS_VERSION) \
+		--namespace $(OADP_NAMESPACE) \
+		--bucket velero \
+		--secret-file $$CRED_FILE \
+		--backup-location-config region=minio,s3ForcePathStyle=true,s3Url=http://minio.$(OADP_NAMESPACE).svc:9000 \
+		--use-volume-snapshots=false; \
+	rm -f $$CRED_FILE
+	@echo ""
+	@echo "Waiting for Velero deployment to be ready..."
+	@kubectl wait --for=condition=available deployment/velero -n $(OADP_NAMESPACE) --timeout=5m
+	@echo "✅ Velero is ready"
+	@echo ""
+	@echo "Installing OADP CRDs..."
+	@kubectl apply -f $(OADP_CRD_BASE_URL)/oadp.openshift.io_dataprotectionapplications.yaml
+	@kubectl apply -f $(OADP_CRD_BASE_URL)/oadp.openshift.io_dataprotectiontests.yaml
+	@echo "✅ OADP CRDs installed"
+	@echo ""
+	@echo "Creating sample DataProtectionApplication..."
+	@echo "$$SAMPLE_DPA" | kubectl apply -f -
+	@echo "✅ Sample DPA created"
+	@echo ""
+	@echo "Waiting for BSL to become available..."
+	@for i in $$(seq 1 60); do \
+		PHASE=$$(kubectl get backupstoragelocation -n $(OADP_NAMESPACE) -o jsonpath='{.items[0].status.phase}' 2>/dev/null); \
+		if [ "$$PHASE" = "Available" ]; then echo "✅ BSL is Available"; break; fi; \
+		if [ $$i -eq 60 ]; then echo "⚠️  BSL not yet Available (phase: $$PHASE) — may need more time"; fi; \
+		sleep 2; \
+	done
+	@echo ""
+	@echo "========================================="
+	@echo "OADP / Velero Installation Complete"
+	@echo "========================================="
+	@echo ""
+	@echo "Velero version: $(VELERO_VERSION)"
+	@echo "Namespace: $(OADP_NAMESPACE)"
+	@echo ""
+	@echo "Verify installation with:"
+	@echo "  make oadp-status"
+	@echo ""
+
+.PHONY: oadp-uninstall
+oadp-uninstall: ## Uninstall Velero and MinIO
+	@echo "Uninstalling Velero and MinIO from $(OADP_NAMESPACE)..."
+	@kubectl delete namespace $(OADP_NAMESPACE) --ignore-not-found
+	@kubectl delete crd -l component=velero --ignore-not-found
+	@kubectl delete crd dataprotectionapplications.oadp.openshift.io --ignore-not-found
+	@kubectl delete crd dataprotectiontests.oadp.openshift.io --ignore-not-found
+	@echo "✅ OADP / Velero uninstalled"
+
+.PHONY: oadp-status
+oadp-status: ## Show OADP / Velero status
+	@echo "========================================="
+	@echo "OADP / Velero Status"
+	@echo "========================================="
+	@echo ""
+	@echo "Namespace:"
+	@kubectl get namespace $(OADP_NAMESPACE) 2>/dev/null || echo "$(OADP_NAMESPACE) namespace not found"
+	@echo ""
+	@echo "Velero Pods:"
+	@kubectl get pods -n $(OADP_NAMESPACE) 2>/dev/null || echo "No pods found"
+	@echo ""
+	@echo "BackupStorageLocations:"
+	@kubectl get backupstoragelocation -n $(OADP_NAMESPACE) 2>/dev/null || echo "No BSLs found"
+	@echo ""
+	@echo "DataProtectionApplications:"
+	@kubectl get dpa -n $(OADP_NAMESPACE) 2>/dev/null || echo "No DPAs found (CRD may not be installed)"
+	@echo ""
+	@echo "Backups:"
+	@kubectl get backups.velero.io -n $(OADP_NAMESPACE) 2>/dev/null || echo "No backups found"
+	@echo ""
+	@echo "Restores:"
+	@kubectl get restores.velero.io -n $(OADP_NAMESPACE) 2>/dev/null || echo "No restores found"
+	@echo ""
+	@echo "Schedules:"
+	@kubectl get schedules.velero.io -n $(OADP_NAMESPACE) 2>/dev/null || echo "No schedules found"
+	@echo ""

--- a/docs/OADP.md
+++ b/docs/OADP.md
@@ -1,0 +1,105 @@
+# OADP Support
+
+The Kubernetes MCP Server supports OpenShift API for Data Protection (OADP) resources using the core toolset's generic resource tools. OADP resources (Velero backups, restores, schedules, and related CRDs) can be managed through the standard `resources_list`, `resources_get`, `resources_create`, and `resources_delete` tools.
+
+The OADP toolset provides a troubleshooting prompt for diagnosing backup and restore issues.
+
+## Prompt
+
+### oadp-troubleshoot
+
+Generate a step-by-step troubleshooting guide for diagnosing OADP backup and restore issues.
+Gathers DPA status, BSL health, recent backup/restore status, Velero pod health, pod logs, and events into a single diagnostic workflow.
+
+**Arguments:**
+- `namespace` (optional): The OADP namespace (default: openshift-adp)
+- `backup` (optional): Name of a specific backup to troubleshoot
+- `restore` (optional): Name of a specific restore to troubleshoot
+
+**Example Usage:**
+```text
+Use the oadp-troubleshoot prompt with namespace=openshift-adp and backup=my-failing-backup
+```
+
+## Enable the OADP Toolset
+
+### Option 1: Command Line
+
+```bash
+kubernetes-mcp-server --toolsets core,config,oadp
+```
+
+### Option 2: Configuration File
+
+```toml
+toolsets = ["core", "config", "oadp"]
+```
+
+### Option 3: MCP Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "kubernetes": {
+      "command": "npx",
+      "args": ["-y", "kubernetes-mcp-server@latest", "--toolsets", "core,config,oadp"]
+    }
+  }
+}
+```
+
+## Prerequisites
+
+OADP support requires:
+
+1. **OADP Operator installed** - The OADP operator must be installed on the cluster
+2. **DataProtectionApplication configured** - At least one DPA must be configured
+3. **Proper RBAC** - The user/service account must have permissions to access Velero CRDs
+
+### Verify OADP Installation
+
+```bash
+# Check OADP operator
+oc get csv -n openshift-adp | grep oadp
+
+# Check DPA
+oc get dpa -n openshift-adp
+
+# Check BSL availability
+oc get backupstoragelocations -n openshift-adp
+```
+
+## Common Use Cases
+
+OADP resources are managed using the core toolset's generic resource tools. Here are common workflows:
+
+### Check OADP Health
+
+Use `resources_list` to check DPA and BSL status:
+- List DPAs: `apiVersion: oadp.openshift.io/v1alpha1`, `kind: DataProtectionApplication`
+- List BSLs: `apiVersion: velero.io/v1`, `kind: BackupStorageLocation`
+
+### Create and Monitor a Backup
+
+1. Create a backup using `resources_create` with `apiVersion: velero.io/v1`, `kind: Backup`
+2. Monitor status using `resources_get`
+
+### Restore from Backup
+
+1. List available backups using `resources_list`
+2. Create a restore using `resources_create` with `apiVersion: velero.io/v1`, `kind: Restore`
+3. Monitor status using `resources_get`
+
+### Set Up Scheduled Backups
+
+Create a schedule using `resources_create` with `apiVersion: velero.io/v1`, `kind: Schedule`
+
+## Troubleshooting
+
+Use the `oadp-troubleshoot` prompt to automatically gather diagnostic information including DPA status, BSL health, Velero pod logs, and recent events.
+
+### Common Issues
+
+- **BSL "Unavailable"**: Check cloud credentials and bucket accessibility
+- **Backup stuck "InProgress"**: Check Velero pod logs for errors
+- **DPA not reconciled**: Verify the OADP operator pod is running

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,10 @@ Choose the guide that matches your needs:
 
 - **[Metrics](./metrics.md)** - Prometheus and Alertmanager tools (`metrics` toolset, via [obs-mcp](https://github.com/rhobs/obs-mcp))
 - **[Tracing](./tracing.md)** - Grafana Tempo and TraceQL (`traces` toolset, via [obs-mcp](https://github.com/rhobs/obs-mcp))
+- **[OADP](OADP.md)** - Tools for OpenShift API for Data Protection (Velero backups, restores, schedules)
 - **[Kiali](KIALI.md)** - Tools for Kiali ServiceMesh with Istio
 - **[KubeVirt](kubevirt.md)** - KubeVirt virtual machine management tools
+- **[Observability](OBSERVABILITY.md)** - Tools for Prometheus metrics and Alertmanager alerts
 
 ## Feature Specifications
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,6 +303,7 @@ Toolsets group related tools together. Enable only the toolsets you need to redu
 | kcp      | Manage kcp workspaces and multi-tenancy features                                                                                                                                |         |
 | kubevirt | KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details. |         |
 | metrics  | Toolset for querying Prometheus and Alertmanager endpoints in efficient ways.                                                                                                   |         |
+| oadp     | OADP (OpenShift API for Data Protection) tools for managing Velero backups, restores, and schedules                                                                             |         |
 | ossm     | Most common tools for managing OSSM, check the [OSSM documentation](https://github.com/openshift/openshift-mcp-server/blob/main/docs/OSSM.md) for more details.                 |         |
 | tekton   | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, and TaskRuns.                                                                                              |         |
 | traces   | Toolset for querying Tempo                                                                                                                                                      |         |

--- a/evals/claude-code/eval.yaml
+++ b/evals/claude-code/eval.yaml
@@ -82,3 +82,13 @@ config:
             toolPattern: ".*"
         minToolCalls: 1
         maxToolCalls: 20
+    # OADP tasks - uses core toolset, requires OADP/Velero on cluster
+    - glob: ../tasks/oadp/*/*.yaml
+      labelSelector:
+        suite: oadp
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 15

--- a/evals/openai-agent/eval.yaml
+++ b/evals/openai-agent/eval.yaml
@@ -82,3 +82,13 @@ config:
             toolPattern: ".*"
         minToolCalls: 1
         maxToolCalls: 20
+    # OADP tasks - uses core toolset, requires OADP/Velero on cluster
+    - glob: ../tasks/oadp/*/*.yaml
+      labelSelector:
+        suite: oadp
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 15

--- a/evals/tasks/oadp/check-dpa-status/check-dpa-status.yaml
+++ b/evals/tasks/oadp/check-dpa-status/check-dpa-status.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "check-oadp-dpa-status"
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Check the status of the OADP DataProtectionApplication (DPA) in the openshift-adp namespace and tell me if it's ready

--- a/evals/tasks/oadp/check-dpa-status/cleanup.sh
+++ b/evals/tasks/oadp/check-dpa-status/cleanup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# No cleanup needed for status check operation
+echo "No cleanup required"

--- a/evals/tasks/oadp/check-dpa-status/setup.sh
+++ b/evals/tasks/oadp/check-dpa-status/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Ensure OADP is installed with a DPA
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+kubectl get crd dataprotectionapplications.oadp.openshift.io || { echo "OADP DPA CRD not found"; exit 1; }
+
+# List DPAs to verify at least one exists
+DPA_COUNT=$(kubectl get dpa -n openshift-adp --no-headers 2>/dev/null | wc -l)
+if [ "$DPA_COUNT" -eq 0 ]; then
+    echo "Warning: No DPA found in openshift-adp namespace"
+fi

--- a/evals/tasks/oadp/check-dpa-status/verify.sh
+++ b/evals/tasks/oadp/check-dpa-status/verify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Verify: Check that DPA CRD is accessible (agent should have called oadp_dpa with action: list or get)
+kubectl get crd dataprotectionapplications.oadp.openshift.io >/dev/null 2>&1
+exit $?

--- a/evals/tasks/oadp/create-backup-auto-bsl/task.yaml
+++ b/evals/tasks/oadp/create-backup-auto-bsl/task.yaml
@@ -1,0 +1,63 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "create-oadp-backup-auto-bsl"
+  difficulty: medium
+  description: "Create a backup without specifying storage location — the tool should auto-discover the available BSL"
+steps:
+  setup:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+
+      kubectl get namespace "$NS" > /dev/null 2>&1 || { echo "OADP namespace not found"; exit 1; }
+      kubectl get crd backups.velero.io > /dev/null 2>&1 || { echo "Velero Backup CRD not found"; exit 1; }
+
+      # Ensure a test namespace exists to back up
+      kubectl create namespace backup-auto-test --dry-run=client -o yaml | kubectl apply -f -
+
+      # Clean up any existing backup
+      kubectl delete backup.velero.io auto-bsl-backup -n "$NS" --ignore-not-found 2>/dev/null || true
+
+      echo "Ready — BSL should be auto-discovered by the tool"
+  verify:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+
+      echo "=== Verification: Checking backup with auto-discovered BSL ==="
+
+      # Check backup was created
+      if ! kubectl get backup.velero.io auto-bsl-backup -n "$NS" > /dev/null 2>&1; then
+          echo "FAIL: Backup 'auto-bsl-backup' not found"
+          exit 1
+      fi
+
+      # Check it targets the correct namespace
+      INCLUDED_NS=$(kubectl get backup.velero.io auto-bsl-backup -n "$NS" -o jsonpath='{.spec.includedNamespaces[0]}')
+      if [ "$INCLUDED_NS" != "backup-auto-test" ]; then
+          echo "FAIL: Backup does not include 'backup-auto-test' namespace (got: $INCLUDED_NS)"
+          exit 1
+      fi
+
+      # Check that a storage location was set (either auto-discovered or explicit)
+      BSL=$(kubectl get backup.velero.io auto-bsl-backup -n "$NS" -o jsonpath='{.spec.storageLocation}')
+      if [ -n "$BSL" ]; then
+          echo "PASS: Backup created with storage location: $BSL"
+      else
+          echo "PASS: Backup created (storage location will use cluster default)"
+      fi
+
+      exit 0
+  cleanup:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+      kubectl delete backup.velero.io auto-bsl-backup -n "$NS" --ignore-not-found 2>/dev/null || true
+      kubectl delete namespace backup-auto-test --ignore-not-found 2>/dev/null || true
+  prompt:
+    inline: |-
+      Create an OADP backup named 'auto-bsl-backup' that backs up the 'backup-auto-test' namespace.
+      Do NOT specify a storage location — the tool should figure out which one to use automatically.

--- a/evals/tasks/oadp/create-backup/cleanup.sh
+++ b/evals/tasks/oadp/create-backup/cleanup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+kubectl delete backup.velero.io app-backup -n openshift-adp --ignore-not-found
+kubectl delete namespace oadp-eval-app --ignore-not-found

--- a/evals/tasks/oadp/create-backup/create-backup.yaml
+++ b/evals/tasks/oadp/create-backup/create-backup.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "create-oadp-backup"
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Create a new OADP backup named 'app-backup' that backs up the 'oadp-eval-app' namespace with a 24-hour TTL

--- a/evals/tasks/oadp/create-backup/setup.sh
+++ b/evals/tasks/oadp/create-backup/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Ensure OADP is installed and create the target namespace
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+kubectl get crd backups.velero.io || { echo "Velero Backup CRD not found"; exit 1; }
+
+# Create a test namespace to back up
+kubectl delete namespace oadp-eval-app --ignore-not-found
+kubectl create namespace oadp-eval-app
+kubectl run nginx --image=nginx --namespace=oadp-eval-app
+
+# Ensure no backup with this name already exists
+kubectl delete backup app-backup -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/create-backup/verify.sh
+++ b/evals/tasks/oadp/create-backup/verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Verify: Check that the backup was created
+# Note: Must use backup.velero.io to avoid conflict with backups.config.openshift.io
+if kubectl get backup.velero.io app-backup -n openshift-adp >/dev/null 2>&1; then
+    # Check that it targets the correct namespace
+    INCLUDED_NS=$(kubectl get backup.velero.io app-backup -n openshift-adp -o jsonpath='{.spec.includedNamespaces[0]}')
+    if [ "$INCLUDED_NS" = "oadp-eval-app" ]; then
+        exit 0
+    else
+        echo "Backup does not include oadp-eval-app namespace"
+        exit 1
+    fi
+else
+    echo "Backup app-backup not found"
+    exit 1
+fi

--- a/evals/tasks/oadp/create-restore/cleanup.sh
+++ b/evals/tasks/oadp/create-restore/cleanup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+kubectl delete restore.velero.io app-restore -n openshift-adp --ignore-not-found
+kubectl delete backup.velero.io restore-source-backup -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/create-restore/create-restore.yaml
+++ b/evals/tasks/oadp/create-restore/create-restore.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "create-oadp-restore"
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Create an OADP restore named 'app-restore' from the backup 'restore-source-backup' in the openshift-adp namespace

--- a/evals/tasks/oadp/create-restore/setup.sh
+++ b/evals/tasks/oadp/create-restore/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Create a completed backup to restore from
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+kubectl get crd restores.velero.io || { echo "Velero Restore CRD not found"; exit 1; }
+
+# Create source backup
+kubectl apply -f - <<EOF
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: restore-source-backup
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+    - default
+  ttl: 1h
+EOF
+
+# Wait for backup to complete
+kubectl wait --for=jsonpath='{.status.phase}'=Completed backup.velero.io/restore-source-backup -n openshift-adp --timeout=120s || true
+
+# Clean up any existing restore
+kubectl delete restore.velero.io app-restore -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/create-restore/verify.sh
+++ b/evals/tasks/oadp/create-restore/verify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Verify: Check that the restore was created from the correct backup
+# Note: Must use restore.velero.io to be explicit about the API group
+if kubectl get restore.velero.io app-restore -n openshift-adp >/dev/null 2>&1; then
+    BACKUP_NAME=$(kubectl get restore.velero.io app-restore -n openshift-adp -o jsonpath='{.spec.backupName}')
+    if [ "$BACKUP_NAME" = "restore-source-backup" ]; then
+        exit 0
+    else
+        echo "Restore does not reference restore-source-backup"
+        exit 1
+    fi
+else
+    echo "Restore app-restore not found"
+    exit 1
+fi

--- a/evals/tasks/oadp/create-schedule/cleanup.sh
+++ b/evals/tasks/oadp/create-schedule/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete schedule.velero.io nightly-backup -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/create-schedule/create-schedule.yaml
+++ b/evals/tasks/oadp/create-schedule/create-schedule.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "create-oadp-schedule"
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Create an OADP backup schedule named 'nightly-backup' that runs every night at 3 AM (cron '0 3 * * *') and backs up the 'production' namespace with a 30-day (720h) TTL

--- a/evals/tasks/oadp/create-schedule/setup.sh
+++ b/evals/tasks/oadp/create-schedule/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Ensure OADP is installed
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+kubectl get crd schedules.velero.io || { echo "Velero Schedule CRD not found"; exit 1; }
+
+# Create target namespace
+kubectl create namespace production --dry-run=client -o yaml | kubectl apply -f -
+
+# Clean up any existing schedule with this name
+kubectl delete schedule nightly-backup -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/create-schedule/verify.sh
+++ b/evals/tasks/oadp/create-schedule/verify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Verify: Check that the schedule was created with correct cron expression
+if kubectl get schedule.velero.io nightly-backup -n openshift-adp >/dev/null 2>&1; then
+    CRON=$(kubectl get schedule.velero.io nightly-backup -n openshift-adp -o jsonpath='{.spec.schedule}')
+    if [ "$CRON" = "0 3 * * *" ]; then
+        exit 0
+    else
+        echo "Schedule has incorrect cron expression: $CRON"
+        exit 1
+    fi
+else
+    echo "Schedule nightly-backup not found"
+    exit 1
+fi

--- a/evals/tasks/oadp/get-backup-status/cleanup.sh
+++ b/evals/tasks/oadp/get-backup-status/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete backup.velero.io status-check-backup -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/get-backup-status/get-backup-status.yaml
+++ b/evals/tasks/oadp/get-backup-status/get-backup-status.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "get-oadp-backup-status"
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Get the status and details of the OADP backup named 'status-check-backup' in the openshift-adp namespace

--- a/evals/tasks/oadp/get-backup-status/setup.sh
+++ b/evals/tasks/oadp/get-backup-status/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Ensure OADP is installed and create a test backup
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+
+# Create a test backup for status check
+kubectl apply -f - <<EOF
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: status-check-backup
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+    - default
+  ttl: 1h
+EOF
+
+# Wait for backup to have some status
+sleep 5

--- a/evals/tasks/oadp/get-backup-status/verify.sh
+++ b/evals/tasks/oadp/get-backup-status/verify.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Verify: Check that the backup exists (agent should have called oadp_backup with action: get)
+# Note: Must use backup.velero.io to avoid conflict with backups.config.openshift.io
+kubectl get backup.velero.io status-check-backup -n openshift-adp >/dev/null 2>&1
+exit $?

--- a/evals/tasks/oadp/list-backups/cleanup.sh
+++ b/evals/tasks/oadp/list-backups/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete backup.velero.io eval-test-backup -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/list-backups/list-backups.yaml
+++ b/evals/tasks/oadp/list-backups/list-backups.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "list-oadp-backups"
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: List all OADP backups in the openshift-adp namespace

--- a/evals/tasks/oadp/list-backups/setup.sh
+++ b/evals/tasks/oadp/list-backups/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Ensure OADP is installed and create a test backup
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+kubectl get crd backups.velero.io || { echo "Velero Backup CRD not found"; exit 1; }
+
+# Create a test backup for the eval
+kubectl apply -f - <<EOF
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: eval-test-backup
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+    - default
+  ttl: 1h
+EOF

--- a/evals/tasks/oadp/list-backups/verify.sh
+++ b/evals/tasks/oadp/list-backups/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Verify: Check that backups were listed (the agent should have called oadp_backup with action: list)
+# The success of this task is validated by the LLM judge checking tool usage patterns
+# This script just verifies the test backup still exists
+# Note: Must use backup.velero.io to avoid conflict with backups.config.openshift.io
+kubectl get backup.velero.io eval-test-backup -n openshift-adp >/dev/null 2>&1
+exit $?

--- a/evals/tasks/oadp/list-schedules/cleanup.sh
+++ b/evals/tasks/oadp/list-schedules/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete schedule.velero.io eval-daily-schedule -n openshift-adp --ignore-not-found

--- a/evals/tasks/oadp/list-schedules/list-schedules.yaml
+++ b/evals/tasks/oadp/list-schedules/list-schedules.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "list-oadp-schedules"
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: List all OADP backup schedules in the openshift-adp namespace

--- a/evals/tasks/oadp/list-schedules/setup.sh
+++ b/evals/tasks/oadp/list-schedules/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Create a test schedule
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+kubectl get crd schedules.velero.io || { echo "Velero Schedule CRD not found"; exit 1; }
+
+kubectl apply -f - <<EOF
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: eval-daily-schedule
+  namespace: openshift-adp
+spec:
+  schedule: "0 2 * * *"
+  template:
+    includedNamespaces:
+      - default
+    ttl: 720h
+EOF

--- a/evals/tasks/oadp/list-schedules/verify.sh
+++ b/evals/tasks/oadp/list-schedules/verify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Verify: Check that the test schedule exists
+kubectl get schedule.velero.io eval-daily-schedule -n openshift-adp >/dev/null 2>&1
+exit $?

--- a/evals/tasks/oadp/list-storage-locations/cleanup.sh
+++ b/evals/tasks/oadp/list-storage-locations/cleanup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# No cleanup needed for list operation
+echo "No cleanup required"

--- a/evals/tasks/oadp/list-storage-locations/list-storage-locations.yaml
+++ b/evals/tasks/oadp/list-storage-locations/list-storage-locations.yaml
@@ -1,0 +1,16 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "list-oadp-storage-locations"
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: List all OADP backup storage locations (BSLs) in the openshift-adp namespace

--- a/evals/tasks/oadp/list-storage-locations/setup.sh
+++ b/evals/tasks/oadp/list-storage-locations/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+# Setup: Ensure OADP is installed
+kubectl get namespace openshift-adp || { echo "OADP namespace not found"; exit 1; }
+kubectl get crd backupstoragelocations.velero.io || { echo "Velero BSL CRD not found"; exit 1; }
+
+# OADP DPA should have created at least one BSL, but verify we can list them
+echo "Checking for existing BSLs..."
+kubectl get backupstoragelocations -n openshift-adp

--- a/evals/tasks/oadp/list-storage-locations/verify.sh
+++ b/evals/tasks/oadp/list-storage-locations/verify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Verify: Check that BSL CRD is accessible (agent should have called oadp_storage_location with action: list, type: bsl)
+kubectl get crd backupstoragelocations.velero.io >/dev/null 2>&1
+exit $?

--- a/evals/tasks/oadp/pause-schedule/task.yaml
+++ b/evals/tasks/oadp/pause-schedule/task.yaml
@@ -1,0 +1,58 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "pause-oadp-schedule"
+  difficulty: medium
+  description: "Pause an active OADP backup schedule and verify it is paused"
+steps:
+  setup:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+
+      # Verify OADP is installed
+      kubectl get crd schedules.velero.io > /dev/null 2>&1 || { echo "Velero Schedule CRD not found"; exit 1; }
+
+      # Clean up any existing schedule
+      kubectl delete schedule.velero.io pause-test-schedule -n "$NS" --ignore-not-found
+
+      # Create an active (unpaused) schedule
+      cat <<EOF | kubectl apply -f -
+      apiVersion: velero.io/v1
+      kind: Schedule
+      metadata:
+        name: pause-test-schedule
+        namespace: $NS
+      spec:
+        schedule: "0 3 * * *"
+        template:
+          includedNamespaces:
+            - default
+          ttl: 720h
+      EOF
+
+      echo "Schedule 'pause-test-schedule' created (active/unpaused)"
+  verify:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+
+      echo "=== Verification: Checking schedule is paused ==="
+
+      PAUSED=$(kubectl get schedule.velero.io pause-test-schedule -n "$NS" -o jsonpath='{.spec.paused}' 2>/dev/null)
+      if [ "$PAUSED" = "true" ]; then
+          echo "PASS: Schedule is paused"
+          exit 0
+      else
+          echo "FAIL: Schedule is not paused (spec.paused=$PAUSED)"
+          exit 1
+      fi
+  cleanup:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+      kubectl delete schedule.velero.io pause-test-schedule -n "$NS" --ignore-not-found
+  prompt:
+    inline: Pause the OADP backup schedule named 'pause-test-schedule' in the openshift-adp namespace

--- a/evals/tasks/oadp/troubleshoot-backup/task.yaml
+++ b/evals/tasks/oadp/troubleshoot-backup/task.yaml
@@ -1,0 +1,77 @@
+kind: Task
+metadata:
+  labels:
+    suite: oadp
+    requires: oadp
+  name: "troubleshoot-oadp-backup"
+  difficulty: hard
+  description: "Use the oadp-troubleshoot prompt to diagnose and fix OADP backup issues"
+steps:
+  setup:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+
+      # Verify OADP is installed
+      if ! kubectl get crd dataprotectionapplications.oadp.openshift.io > /dev/null 2>&1; then
+          echo "OADP CRD not found - OADP must be installed"
+          exit 1
+      fi
+
+      # Create a backup that will fail (referencing a non-existent BSL)
+      cat <<EOF | kubectl apply -f -
+      apiVersion: velero.io/v1
+      kind: Backup
+      metadata:
+        name: failing-backup
+        namespace: $NS
+      spec:
+        includedNamespaces:
+          - oadp-eval-app
+        storageLocation: non-existent-bsl
+        ttl: 1h
+      EOF
+
+      echo "Created backup referencing non-existent BSL - waiting for failure"
+      sleep 10
+  verify:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+
+      echo "=== Verification: Checking if agent diagnosed the issue ==="
+
+      # The agent should have identified that the backup failed because
+      # it references a non-existent BSL. The main success criteria is
+      # that the agent used the oadp-troubleshoot prompt and identified
+      # the root cause.
+
+      # Check if the failing backup still exists (agent should not have deleted it)
+      if kubectl get backup.velero.io failing-backup -n "$NS" > /dev/null 2>&1; then
+          PHASE=$(kubectl get backup.velero.io failing-backup -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+          echo "Backup exists with phase: $PHASE"
+      fi
+
+      echo ""
+      echo "=== Troubleshooting Eval Complete ==="
+      echo "The agent should have:"
+      echo "  1. Used the oadp-troubleshoot prompt to gather diagnostic data"
+      echo "  2. Identified the root cause (backup references non-existent BSL 'non-existent-bsl')"
+      echo "  3. Reported findings with status, root cause, and recommended action"
+      echo ""
+
+      exit 0
+  cleanup:
+    inline: |-
+      #!/usr/bin/env bash
+      NS="openshift-adp"
+      kubectl delete backup.velero.io failing-backup -n "$NS" --ignore-not-found
+  prompt:
+    inline: |-
+      There is an OADP backup named "failing-backup" in the openshift-adp namespace that is not completing successfully.
+
+      Please use the oadp-troubleshoot prompt to diagnose the issue.
+      Follow the troubleshooting guide to identify the problem and report your findings including:
+      - The root cause of the issue
+      - What action should be taken to fix it
+      - The current status of the OADP environment

--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kcp"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/oadp"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/tekton"
 	_ "github.com/rhobs/obs-mcp/pkg/toolset"
 )

--- a/pkg/mcp/modules.go
+++ b/pkg/mcp/modules.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/netedge"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/oadp"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/openshift"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/tekton"
 	_ "github.com/rhobs/obs-mcp/pkg/toolset"

--- a/pkg/oadp/backup.go
+++ b/pkg/oadp/backup.go
@@ -1,0 +1,19 @@
+package oadp
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// GetBackup retrieves a Backup by namespace and name
+func GetBackup(ctx context.Context, client dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	return client.Resource(BackupGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// ListBackups lists all backups in a namespace
+func ListBackups(ctx context.Context, client dynamic.Interface, namespace string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return client.Resource(BackupGVR).Namespace(namespace).List(ctx, opts)
+}

--- a/pkg/oadp/dpa.go
+++ b/pkg/oadp/dpa.go
@@ -1,0 +1,14 @@
+package oadp
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// ListDataProtectionApplications lists all DataProtectionApplications in a namespace
+func ListDataProtectionApplications(ctx context.Context, client dynamic.Interface, namespace string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return client.Resource(DataProtectionApplicationGVR).Namespace(namespace).List(ctx, opts)
+}

--- a/pkg/oadp/resources.go
+++ b/pkg/oadp/resources.go
@@ -1,0 +1,48 @@
+package oadp
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// VeleroGroup is the API group for Velero resources
+	VeleroGroup = "velero.io"
+	// VeleroVersion is the API version for Velero resources
+	VeleroVersion = "v1"
+	// OADPGroup is the API group for OADP resources
+	OADPGroup = "oadp.openshift.io"
+	// OADPVersion is the API version for OADP resources
+	OADPVersion = "v1alpha1"
+	// DefaultOADPNamespace is the default namespace where OADP is installed
+	DefaultOADPNamespace = "openshift-adp"
+)
+
+var (
+	// BackupGVR is the GroupVersionResource for Velero Backup resources
+	BackupGVR = schema.GroupVersionResource{
+		Group:    VeleroGroup,
+		Version:  VeleroVersion,
+		Resource: "backups",
+	}
+
+	// RestoreGVR is the GroupVersionResource for Velero Restore resources
+	RestoreGVR = schema.GroupVersionResource{
+		Group:    VeleroGroup,
+		Version:  VeleroVersion,
+		Resource: "restores",
+	}
+
+	// BackupStorageLocationGVR is the GroupVersionResource for Velero BackupStorageLocation resources
+	BackupStorageLocationGVR = schema.GroupVersionResource{
+		Group:    VeleroGroup,
+		Version:  VeleroVersion,
+		Resource: "backupstoragelocations",
+	}
+
+	// DataProtectionApplicationGVR is the GroupVersionResource for OADP DataProtectionApplication resources
+	DataProtectionApplicationGVR = schema.GroupVersionResource{
+		Group:    OADPGroup,
+		Version:  OADPVersion,
+		Resource: "dataprotectionapplications",
+	}
+)

--- a/pkg/oadp/restore.go
+++ b/pkg/oadp/restore.go
@@ -1,0 +1,19 @@
+package oadp
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// GetRestore retrieves a Restore by namespace and name
+func GetRestore(ctx context.Context, client dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	return client.Resource(RestoreGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// ListRestores lists all restores in a namespace
+func ListRestores(ctx context.Context, client dynamic.Interface, namespace string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return client.Resource(RestoreGVR).Namespace(namespace).List(ctx, opts)
+}

--- a/pkg/oadp/storage.go
+++ b/pkg/oadp/storage.go
@@ -1,0 +1,14 @@
+package oadp
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// ListBackupStorageLocations lists all BackupStorageLocations in a namespace
+func ListBackupStorageLocations(ctx context.Context, client dynamic.Interface, namespace string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return client.Resource(BackupStorageLocationGVR).Namespace(namespace).List(ctx, opts)
+}

--- a/pkg/toolsets/oadp/oadp_troubleshoot.go
+++ b/pkg/toolsets/oadp/oadp_troubleshoot.go
@@ -1,0 +1,655 @@
+package oadp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/oadp"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+)
+
+// initOADPTroubleshoot initializes the OADP troubleshooting prompt
+func initOADPTroubleshoot() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "oadp-troubleshoot",
+				Title:       "OADP Troubleshoot",
+				Description: "Generate a step-by-step troubleshooting guide for diagnosing OADP backup and restore issues",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "The OADP namespace (default: openshift-adp)",
+						Required:    false,
+					},
+					{
+						Name:        "backup",
+						Description: "The name of a specific backup to troubleshoot",
+						Required:    false,
+					},
+					{
+						Name:        "restore",
+						Description: "The name of a specific restore to troubleshoot",
+						Required:    false,
+					},
+				},
+			},
+			Handler: oadpTroubleshootHandler,
+		},
+	}
+}
+
+// oadpTroubleshootHandler implements the OADP troubleshooting prompt
+func oadpTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespace := args["namespace"]
+	if namespace == "" {
+		namespace = oadp.DefaultOADPNamespace
+	}
+	backupName := args["backup"]
+	restoreName := args["restore"]
+
+	ctx := params.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	dynamicClient := params.DynamicClient()
+
+	// Fetch all relevant OADP resources
+	dpaYaml := fetchDPAStatus(ctx, dynamicClient, namespace)
+	bslYaml := fetchBSLStatus(ctx, dynamicClient, namespace)
+	veleroPodYaml, podNames := fetchVeleroPods(ctx, dynamicClient, namespace)
+	veleroLogsText := fetchVeleroPodLogs(ctx, params.KubernetesClient, namespace, podNames)
+	eventsYaml := fetchOADPEvents(ctx, params.KubernetesClient, namespace)
+
+	// Optionally fetch specific backup/restore details
+	backupYaml := ""
+	if backupName != "" {
+		backupYaml = fetchBackupDetails(ctx, dynamicClient, namespace, backupName)
+	} else {
+		backupYaml = fetchRecentBackups(ctx, dynamicClient, namespace)
+	}
+
+	restoreYaml := ""
+	if restoreName != "" {
+		restoreYaml = fetchRestoreDetails(ctx, dynamicClient, namespace, restoreName)
+	} else {
+		restoreYaml = fetchRecentRestores(ctx, dynamicClient, namespace)
+	}
+
+	guideText := fmt.Sprintf(`# OADP Troubleshooting Guide
+
+## Namespace: %s
+
+Use this guide to diagnose issues with OADP backups and restores. The relevant resource data has been collected below.
+
+---
+
+## Step 1: DataProtectionApplication (DPA) Status
+
+The DPA is the central configuration for OADP. Check:
+- Does a DPA exist?
+- Are the conditions healthy (type "Reconciled" with status "True")?
+- Is the backup storage location configured correctly?
+
+%s
+
+---
+
+## Step 2: BackupStorageLocation (BSL) Status
+
+BSLs define where backups are stored. Check:
+- phase should be "Available"
+- If "Unavailable": credentials may be wrong, bucket may not exist, or network access may be blocked
+- lastValidationTime should be recent
+
+%s
+
+---
+
+## Step 3: Backups
+
+Review backup status:
+- phase "Completed" = success
+- phase "PartiallyFailed" = some resources failed to back up (check errors/warnings)
+- phase "Failed" = backup failed entirely
+- phase "InProgress" for extended time = backup may be stuck
+
+%s
+
+---
+
+## Step 4: Restores
+
+Review restore status:
+- phase "Completed" = success
+- phase "PartiallyFailed" = some resources failed to restore
+- phase "Failed" = restore failed entirely
+- Check that the referenced backup exists and is in "Completed" phase
+
+%s
+
+---
+
+## Step 5: Velero Pod Health
+
+Check the Velero server pod:
+- Pod should be "Running" with all containers ready
+- Check for restart counts (frequent restarts indicate crashes)
+- nodeAgent pods should also be running if file-system backup is configured
+
+%s
+
+---
+
+## Step 6: Velero Pod Logs
+
+Review logs from the Velero server for errors:
+- Look for "error" or "level=error" messages
+- Check for credential/authentication failures
+- Check for storage access issues
+
+%s
+
+---
+
+## Step 7: Events
+
+Review events in the OADP namespace:
+- Warning events indicate problems
+- Look for scheduling, storage, or permission issues
+
+%s
+
+---
+
+## Troubleshooting Analysis
+
+Based on the data above, analyze:
+
+1. **DPA Health**: Is the DPA reconciled and healthy?
+2. **BSL Availability**: Is the backup storage location "Available"?
+3. **Backup/Restore Status**: Are operations completing successfully or failing?
+4. **Velero Pod**: Is the Velero server running without restarts?
+5. **Credentials**: Are cloud credentials configured correctly?
+6. **Events**: Are there Warning events indicating problems?
+
+---
+
+## Common Issues and Fixes
+
+1. **BSL "Unavailable"**: Check cloud credentials secret exists and has correct keys. Verify bucket exists and is accessible.
+2. **Backup stuck "InProgress"**: Check Velero pod logs for errors. The pod may need restarting.
+3. **Backup "PartiallyFailed"**: Some resources could not be backed up. Check backup status for per-resource errors.
+4. **Restore "Failed"**: The referenced backup may not exist or may not be in "Completed" phase. Check that the BSL containing the backup is available.
+5. **DPA not reconciled**: The OADP operator may not be running. Check the operator pod in the openshift-adp namespace.
+6. **NodeAgent not running**: If using file-system backups, ensure nodeAgent is enabled in the DPA configuration.
+
+Use the OADP tools to apply fixes (create/update DPA, check storage locations, retry backups).
+
+---
+
+## Report Findings
+
+After completing troubleshooting and attempting fixes, report:
+- **Status:** Healthy/Degraded/Failed
+- **Root Cause:** Description or "None found"
+- **Action Taken:** What was done to fix the issue (or "None" if no fix was needed/possible)
+- **Result:** Whether the fix was successful or further action is needed
+`, namespace, dpaYaml, bslYaml, backupYaml, restoreYaml, veleroPodYaml, veleroLogsText, eventsYaml)
+
+	return api.NewPromptCallResult(
+		"OADP troubleshooting guide generated",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: guideText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the collected OADP data to diagnose backup and restore issues systematically.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+// fetchDPAStatus fetches all DPA resources and returns their status as YAML
+func fetchDPAStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace string) string {
+	dpas, err := oadp.ListDataProtectionApplications(ctx, dynamicClient, namespace, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### DataProtectionApplication\n\n*Error listing DPAs: %v*", err)
+	}
+
+	if len(dpas.Items) == 0 {
+		return "### DataProtectionApplication\n\n*No DataProtectionApplication found — OADP may not be configured*"
+	}
+
+	var result strings.Builder
+	result.WriteString("### DataProtectionApplication\n\n")
+	for _, dpa := range dpas.Items {
+		status, found, err := unstructured.NestedMap(dpa.Object, "status")
+		if err != nil {
+			fmt.Fprintf(&result, "#### %s\n\n*Error extracting status: %v*\n\n", dpa.GetName(), err)
+			continue
+		}
+		if !found {
+			fmt.Fprintf(&result, "#### %s\n\n*No status found (DPA may still be reconciling)*\n\n", dpa.GetName())
+			continue
+		}
+		yamlStr, err := output.MarshalYaml(status)
+		if err != nil {
+			fmt.Fprintf(&result, "#### %s\n\n*Error marshaling status: %v*\n\n", dpa.GetName(), err)
+			continue
+		}
+		fmt.Fprintf(&result, "#### %s\n\n```yaml\n%s```\n\n", dpa.GetName(), yamlStr)
+	}
+
+	return result.String()
+}
+
+// fetchBSLStatus fetches all BSL resources and returns their status as YAML
+func fetchBSLStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace string) string {
+	bsls, err := oadp.ListBackupStorageLocations(ctx, dynamicClient, namespace, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### BackupStorageLocations\n\n*Error listing BSLs: %v*", err)
+	}
+
+	if len(bsls.Items) == 0 {
+		return "### BackupStorageLocations\n\n*No BackupStorageLocations found*"
+	}
+
+	var result strings.Builder
+	result.WriteString("### BackupStorageLocations\n\n")
+	for _, bsl := range bsls.Items {
+		phase, _, err := unstructured.NestedString(bsl.Object, "status", "phase")
+		if err != nil {
+			phase = ""
+		}
+		lastValidation, _, err := unstructured.NestedString(bsl.Object, "status", "lastValidationTime")
+		if err != nil {
+			lastValidation = ""
+		}
+		provider, _, err := unstructured.NestedString(bsl.Object, "spec", "provider")
+		if err != nil {
+			provider = ""
+		}
+		bucket, _, err := unstructured.NestedString(bsl.Object, "spec", "objectStorage", "bucket")
+		if err != nil {
+			bucket = ""
+		}
+
+		fmt.Fprintf(&result, "#### %s\n\n", bsl.GetName())
+		fmt.Fprintf(&result, "- **Phase:** %s\n", valueOrNA(phase))
+		fmt.Fprintf(&result, "- **Provider:** %s\n", valueOrNA(provider))
+		fmt.Fprintf(&result, "- **Bucket:** %s\n", valueOrNA(bucket))
+		fmt.Fprintf(&result, "- **Last Validation:** %s\n\n", valueOrNA(lastValidation))
+	}
+
+	return result.String()
+}
+
+// fetchRecentBackups fetches the most recent backups and summarizes their status
+func fetchRecentBackups(ctx context.Context, dynamicClient dynamic.Interface, namespace string) string {
+	backups, err := oadp.ListBackups(ctx, dynamicClient, namespace, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### Recent Backups\n\n*Error listing backups: %v*", err)
+	}
+
+	if len(backups.Items) == 0 {
+		return "### Recent Backups\n\n*No backups found*"
+	}
+
+	var result strings.Builder
+	result.WriteString("### Recent Backups\n\n")
+	result.WriteString("| Name | Phase | Started | Completed | Errors | Warnings |\n")
+	result.WriteString("|------|-------|---------|-----------|--------|----------|\n")
+
+	for _, backup := range backups.Items {
+		phase, _, err := unstructured.NestedString(backup.Object, "status", "phase")
+		if err != nil {
+			phase = ""
+		}
+		startTime, _, err := unstructured.NestedString(backup.Object, "status", "startTimestamp")
+		if err != nil {
+			startTime = ""
+		}
+		completionTime, _, err := unstructured.NestedString(backup.Object, "status", "completionTimestamp")
+		if err != nil {
+			completionTime = ""
+		}
+		errors, _, err := unstructured.NestedInt64(backup.Object, "status", "errors")
+		if err != nil {
+			errors = 0
+		}
+		warnings, _, err := unstructured.NestedInt64(backup.Object, "status", "warnings")
+		if err != nil {
+			warnings = 0
+		}
+
+		fmt.Fprintf(&result, "| %s | %s | %s | %s | %d | %d |\n",
+			backup.GetName(), valueOrNA(phase), valueOrNA(startTime), valueOrNA(completionTime), errors, warnings)
+	}
+	result.WriteString("\n")
+
+	return result.String()
+}
+
+// fetchBackupDetails fetches a specific backup and returns full details
+func fetchBackupDetails(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) string {
+	backup, err := oadp.GetBackup(ctx, dynamicClient, namespace, name)
+	if err != nil {
+		return fmt.Sprintf("### Backup: %s\n\n*Error fetching backup: %v*", name, err)
+	}
+
+	status, found, err := unstructured.NestedMap(backup.Object, "status")
+	if err != nil {
+		return fmt.Sprintf("### Backup: %s\n\n*Error extracting status: %v*", name, err)
+	}
+	if !found {
+		return fmt.Sprintf("### Backup: %s\n\n*No status found (backup may not have started)*", name)
+	}
+
+	spec, _, err := unstructured.NestedMap(backup.Object, "spec")
+	if err != nil {
+		spec = nil
+	}
+
+	var result strings.Builder
+	fmt.Fprintf(&result, "### Backup: %s\n\n", name)
+
+	if spec != nil {
+		specYaml, err := output.MarshalYaml(spec)
+		if err == nil {
+			fmt.Fprintf(&result, "**Spec:**\n```yaml\n%s```\n\n", specYaml)
+		}
+	}
+
+	statusYaml, err := output.MarshalYaml(status)
+	if err == nil {
+		fmt.Fprintf(&result, "**Status:**\n```yaml\n%s```\n\n", statusYaml)
+	}
+
+	return result.String()
+}
+
+// fetchRecentRestores fetches the most recent restores and summarizes their status
+func fetchRecentRestores(ctx context.Context, dynamicClient dynamic.Interface, namespace string) string {
+	restores, err := oadp.ListRestores(ctx, dynamicClient, namespace, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### Recent Restores\n\n*Error listing restores: %v*", err)
+	}
+
+	if len(restores.Items) == 0 {
+		return "### Recent Restores\n\n*No restores found*"
+	}
+
+	var result strings.Builder
+	result.WriteString("### Recent Restores\n\n")
+	result.WriteString("| Name | Phase | Backup | Started | Completed | Errors | Warnings |\n")
+	result.WriteString("|------|-------|--------|---------|-----------|--------|----------|\n")
+
+	for _, restore := range restores.Items {
+		phase, _, err := unstructured.NestedString(restore.Object, "status", "phase")
+		if err != nil {
+			phase = ""
+		}
+		backupName, _, err := unstructured.NestedString(restore.Object, "spec", "backupName")
+		if err != nil {
+			backupName = ""
+		}
+		startTime, _, err := unstructured.NestedString(restore.Object, "status", "startTimestamp")
+		if err != nil {
+			startTime = ""
+		}
+		completionTime, _, err := unstructured.NestedString(restore.Object, "status", "completionTimestamp")
+		if err != nil {
+			completionTime = ""
+		}
+		errors, _, err := unstructured.NestedInt64(restore.Object, "status", "errors")
+		if err != nil {
+			errors = 0
+		}
+		warnings, _, err := unstructured.NestedInt64(restore.Object, "status", "warnings")
+		if err != nil {
+			warnings = 0
+		}
+
+		fmt.Fprintf(&result, "| %s | %s | %s | %s | %s | %d | %d |\n",
+			restore.GetName(), valueOrNA(phase), valueOrNA(backupName), valueOrNA(startTime), valueOrNA(completionTime), errors, warnings)
+	}
+	result.WriteString("\n")
+
+	return result.String()
+}
+
+// fetchRestoreDetails fetches a specific restore and returns full details
+func fetchRestoreDetails(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) string {
+	restore, err := oadp.GetRestore(ctx, dynamicClient, namespace, name)
+	if err != nil {
+		return fmt.Sprintf("### Restore: %s\n\n*Error fetching restore: %v*", name, err)
+	}
+
+	status, found, err := unstructured.NestedMap(restore.Object, "status")
+	if err != nil {
+		return fmt.Sprintf("### Restore: %s\n\n*Error extracting status: %v*", name, err)
+	}
+	if !found {
+		return fmt.Sprintf("### Restore: %s\n\n*No status found (restore may not have started)*", name)
+	}
+
+	spec, _, err := unstructured.NestedMap(restore.Object, "spec")
+	if err != nil {
+		spec = nil
+	}
+
+	var result strings.Builder
+	fmt.Fprintf(&result, "### Restore: %s\n\n", name)
+
+	if spec != nil {
+		specYaml, err := output.MarshalYaml(spec)
+		if err == nil {
+			fmt.Fprintf(&result, "**Spec:**\n```yaml\n%s```\n\n", specYaml)
+		}
+	}
+
+	statusYaml, err := output.MarshalYaml(status)
+	if err == nil {
+		fmt.Fprintf(&result, "**Status:**\n```yaml\n%s```\n\n", statusYaml)
+	}
+
+	return result.String()
+}
+
+// fetchVeleroPods fetches the Velero server and NodeAgent pods
+func fetchVeleroPods(ctx context.Context, dynamicClient dynamic.Interface, namespace string) (string, []string) {
+	gvr := podGVR()
+
+	// Fetch Velero server pods
+	podList, err := dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=velero",
+	})
+	if err != nil {
+		return fmt.Sprintf("### Velero Pods\n\n*Error listing pods: %v*", err), nil
+	}
+
+	// Also fetch NodeAgent pods
+	nodeAgentList, err := dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "name=node-agent",
+	})
+	if err == nil && len(nodeAgentList.Items) > 0 {
+		podList.Items = append(podList.Items, nodeAgentList.Items...)
+	}
+
+	if len(podList.Items) == 0 {
+		return "### Velero Pods\n\n*No Velero pods found — the OADP operator may not be installed or the DPA may not be configured*", nil
+	}
+
+	var result strings.Builder
+	var podNames []string
+	result.WriteString("### Velero Pods\n\n")
+	result.WriteString("| Name | Phase | Ready | Restarts | Age |\n")
+	result.WriteString("|------|-------|-------|----------|-----|\n")
+
+	for _, pod := range podList.Items {
+		podNames = append(podNames, pod.GetName())
+		phase, _, err := unstructured.NestedString(pod.Object, "status", "phase")
+		if err != nil {
+			phase = ""
+		}
+		creationTime := pod.GetCreationTimestamp().Format("2006-01-02T15:04:05Z")
+
+		// Get ready and restart counts from container statuses
+		ready, restarts := getPodReadyAndRestarts(&pod)
+
+		fmt.Fprintf(&result, "| %s | %s | %s | %d | %s |\n",
+			pod.GetName(), phase, ready, restarts, creationTime)
+	}
+	result.WriteString("\n")
+
+	return result.String(), podNames
+}
+
+// fetchVeleroPodLogs fetches logs from the Velero server pod
+func fetchVeleroPodLogs(ctx context.Context, client api.KubernetesClient, namespace string, podNames []string) string {
+	if len(podNames) == 0 {
+		return "### Velero Pod Logs\n\n*No Velero pods found — no logs available*"
+	}
+
+	core := kubernetes.NewCore(client)
+	var result strings.Builder
+	result.WriteString("### Velero Pod Logs\n\n")
+
+	for _, podName := range podNames {
+		// Only fetch logs from velero server pods, not node-agent
+		if strings.HasPrefix(podName, "node-agent") {
+			continue
+		}
+
+		fmt.Fprintf(&result, "#### Pod: %s\n\n", podName)
+		logs, err := core.PodsLog(ctx, namespace, podName, "velero", false, 100)
+		if err != nil {
+			fmt.Fprintf(&result, "*Error fetching logs: %v*\n\n", err)
+			continue
+		}
+
+		// Filter for error/warning lines to keep output focused
+		errorLines := filterLogLines(logs, []string{"error", "level=error", "level=warning", "Failed", "forbidden"})
+		if errorLines != "" {
+			fmt.Fprintf(&result, "**Error/Warning lines (last 100 log lines):**\n```\n%s\n```\n\n", errorLines)
+		} else {
+			result.WriteString("*No error or warning lines found in recent logs*\n\n")
+		}
+	}
+
+	return result.String()
+}
+
+// fetchOADPEvents fetches events in the OADP namespace
+func fetchOADPEvents(ctx context.Context, client api.KubernetesClient, namespace string) string {
+	core := kubernetes.NewCore(client)
+	eventMap, err := core.EventsList(ctx, namespace, api.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### Events\n\n*Error listing events: %v*", err)
+	}
+
+	if len(eventMap) == 0 {
+		return "### Events\n\n*No events found in namespace*"
+	}
+
+	// Filter for warning events which indicate problems
+	var warningEvents []map[string]any
+	for _, event := range eventMap {
+		eventType, _ := event["Type"].(string)
+		if eventType == "Warning" {
+			warningEvents = append(warningEvents, event)
+		}
+	}
+
+	if len(warningEvents) == 0 {
+		return "### Events\n\n*No Warning events found — this is good*"
+	}
+
+	yamlStr, err := output.MarshalYaml(warningEvents)
+	if err != nil {
+		return fmt.Sprintf("### Events\n\n*Error marshaling events: %v*", err)
+	}
+
+	return fmt.Sprintf("### Warning Events\n\n```yaml\n%s```", yamlStr)
+}
+
+// Helper functions
+
+func valueOrNA(s string) string {
+	if s == "" {
+		return "N/A"
+	}
+	return s
+}
+
+func getPodReadyAndRestarts(pod *unstructured.Unstructured) (string, int64) {
+	containerStatuses, found, _ := unstructured.NestedSlice(pod.Object, "status", "containerStatuses")
+	if !found {
+		return "N/A", 0
+	}
+
+	totalContainers := len(containerStatuses)
+	readyCount := 0
+	var totalRestarts int64
+
+	for _, cs := range containerStatuses {
+		csMap, ok := cs.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ready, ok := csMap["ready"].(bool); ok && ready {
+			readyCount++
+		}
+		switch restarts := csMap["restartCount"].(type) {
+		case int64:
+			totalRestarts += restarts
+		case float64:
+			totalRestarts += int64(restarts)
+		}
+	}
+
+	return fmt.Sprintf("%d/%d", readyCount, totalContainers), totalRestarts
+}
+
+func filterLogLines(logs string, keywords []string) string {
+	var matched []string
+	for _, line := range strings.Split(logs, "\n") {
+		lower := strings.ToLower(line)
+		for _, kw := range keywords {
+			if strings.Contains(lower, strings.ToLower(kw)) {
+				matched = append(matched, line)
+				break
+			}
+		}
+	}
+	return strings.Join(matched, "\n")
+}
+
+// podGVR returns the Pod GVR
+func podGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
+}

--- a/pkg/toolsets/oadp/toolset.go
+++ b/pkg/toolsets/oadp/toolset.go
@@ -1,0 +1,48 @@
+package oadp
+
+import (
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
+)
+
+// Toolset provides OADP (OpenShift API for Data Protection) prompts for managing
+// Velero backups, restores, and schedules on OpenShift clusters.
+// OADP resources are managed via the core toolset's generic resource tools.
+// This toolset provides a troubleshooting prompt for diagnosing backup/restore issues.
+type Toolset struct{}
+
+var _ api.Toolset = (*Toolset)(nil)
+
+// GetName returns the name of the toolset.
+func (t *Toolset) GetName() string {
+	return "oadp"
+}
+
+// GetDescription returns a human-readable description of the toolset.
+func (t *Toolset) GetDescription() string {
+	return "OADP (OpenShift API for Data Protection) tools for managing Velero backups, restores, and schedules"
+}
+
+// GetTools returns nil — OADP resources are managed via the core toolset's generic resource tools.
+func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
+	return nil
+}
+
+// GetPrompts returns the prompts provided by this toolset.
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
+	return initOADPTroubleshoot()
+}
+
+// GetResources returns the resources provided by this toolset.
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+// GetResourceTemplates returns the resource templates provided by this toolset.
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
+func init() {
+	toolsets.Register(&Toolset{})
+}


### PR DESCRIPTION
## Summary

Adds OADP (OpenShift API for Data Protection) support to the kubernetes-mcp-server. OADP resources are managed via the core toolset's generic resource tools. This PR adds evals, a troubleshooting prompt, eval infrastructure, and documentation.

Fixes https://redhat.atlassian.net/browse/OADP-7194

### What's Included

**Evals (11 tasks):** Validate OADP workflows using the core toolset -- backup, restore, schedule, DPA, and storage location operations. All tasks labeled with `suite: oadp`.

**Troubleshooting Prompt:** `oadp-troubleshoot` aggregates DPA status, BSL health, recent backup/restore status, Velero pod health, logs, and events into a single diagnostic workflow.

**Eval Infrastructure:** Make targets for setting up Velero + MinIO on Kind clusters:
- `make local-env-setup-oadp` -- one-command Kind cluster + OADP setup
- `make oadp-install` / `make oadp-uninstall` / `make oadp-status`

**Documentation:** `docs/OADP.md` with usage guidance for managing OADP resources via the core toolset.

### Background

Eval results confirmed that all 11 OADP tasks pass with the core toolset (44/44 tasks, 132/132 assertions across multiple configurations). Based on reviewer feedback, dedicated OADP tools were removed in favor of the core toolset's generic resource tools.

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] `make oadp-install` sets up Velero + MinIO on a Kind cluster
- [x] `make oadp-status` shows healthy BSL and DPA
- [x] OADP eval tasks pass with core toolset via mcpchecker