### PR TITLE
For DP we start with default of read-only and the core/config tools

### DIFF
--- a/pkg/config/config_default_overrides.go
+++ b/pkg/config/config_default_overrides.go
@@ -3,6 +3,8 @@ package config
 func defaultOverrides() StaticConfig {
 	return StaticConfig{
 		// IMPORTANT: this file is used to override default config values in downstream builds.
-		// This is intentionally left blank.
+		// For current release we want to just expose the settings below:
+		ReadOnly: true,
+		Toolsets: []string{"core", "config"},
 	}
 }


### PR DESCRIPTION
Start with "just" `read-only` and the tools for `core` and `config` 

Users _still_ can set `read-only: false` on their own custom cfg file 