### PR TITLE
OLS-2568: Add _meta field support for tool definitions

### DIFF
--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -88,6 +88,9 @@ type Tool struct {
 	Description string `json:"description,omitempty"`
 	// Additional tool information.
 	Annotations ToolAnnotations `json:"annotations"`
+	// Meta contains additional metadata for the tool (e.g., MCP Apps UI resource URI).
+	// Example: map[string]any{"ui": map[string]any{"resourceUri": "ui://server/app.html"}}
+	Meta map[string]any `json:"_meta,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
 	InputSchema *jsonschema.Schema
 }

--- a/pkg/mcp/gosdk.go
+++ b/pkg/mcp/gosdk.go
@@ -16,6 +16,7 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		Name:        tool.Tool.Name,
 		Description: tool.Tool.Description,
 		Title:       tool.Tool.Annotations.Title,
+		Meta:        mcp.Meta(tool.Tool.Meta),
 		Annotations: &mcp.ToolAnnotations{
 			Title:           tool.Tool.Annotations.Title,
 			ReadOnlyHint:    ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false),


### PR DESCRIPTION
**Purpose:** Allow tool definitions to carry a `_meta` map, which the MCP Apps spec uses for `ui.resourceUri` to link a tool to its UI resource.

**Files changed:**

- [pkg/api/toolsets.go](pkg/api/toolsets.go) -- Add `Meta map[string]any` field with `json:"_meta,omitempty"` to the `Tool` struct
- [pkg/mcp/gosdk.go](pkg/mcp/gosdk.go) -- Pass `Meta: mcp.Meta(tool.Tool.Meta)` when converting to Go SDK tool