### PR TITLE
NE-2453: Implement exec_dns_in_pod diagnostic tool

### DIFF
--- a/pkg/toolsets/netedge/exec_dns_in_pod.go
+++ b/pkg/toolsets/netedge/exec_dns_in_pod.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -130,7 +132,7 @@ func initExecDNSInPodWith(executor podExecutor) []api.ServerTool {
 					Title:           "Exec DNS in Pod",
 					ReadOnlyHint:    ptr.To(false),
 					DestructiveHint: ptr.To(false),
-					IdempotentHint:  ptr.To(true),
+					IdempotentHint:  ptr.To(false),
 					OpenWorldHint:   ptr.To(true),
 				},
 			},
@@ -150,15 +152,24 @@ func makeExecDNSInPodHandler(executor podExecutor) api.ToolHandlerFunc {
 		if !ok || targetServer == "" {
 			return api.NewToolCallResultStructured(nil, fmt.Errorf("target_server parameter is required")), nil
 		}
+		if net.ParseIP(targetServer) == nil {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("target_server must be a valid IP address")), nil
+		}
 
 		targetName, ok := params.GetArguments()["target_name"].(string)
 		if !ok || targetName == "" {
 			return api.NewToolCallResultStructured(nil, fmt.Errorf("target_name parameter is required")), nil
 		}
+		if strings.ContainsAny(targetName, " \t\r\n") || strings.HasPrefix(targetName, "-") || strings.HasPrefix(targetName, "+") || strings.HasPrefix(targetName, "@") {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("target_name must be a DNS name, not a dig option")), nil
+		}
 
 		recordType, ok := params.GetArguments()["record_type"].(string)
 		if !ok || recordType == "" {
 			recordType = "A"
+		}
+		if strings.ContainsAny(recordType, " \t\r\n") || strings.HasPrefix(recordType, "-") || strings.HasPrefix(recordType, "+") || strings.HasPrefix(recordType, "@") {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("record_type must be a DNS record type, not a dig option")), nil
 		}
 
 		// Use provided executor or create one from the KubernetesClient
@@ -175,7 +186,8 @@ func makeExecDNSInPodHandler(executor podExecutor) api.ToolHandlerFunc {
 				Namespace: namespace,
 			},
 			Spec: corev1.PodSpec{
-				RestartPolicy: corev1.RestartPolicyNever,
+				AutomountServiceAccountToken: ptr.To(false),
+				RestartPolicy:                corev1.RestartPolicyNever,
 				Containers: []corev1.Container{
 					{
 						Name:    "dns-probe",

--- a/pkg/toolsets/netedge/exec_dns_in_pod.go
+++ b/pkg/toolsets/netedge/exec_dns_in_pod.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/google/jsonschema-go/jsonschema"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
@@ -25,6 +26,19 @@ const (
 	dnsProbePollPeriod = 2 * time.Second
 	dnsProbeTimeout    = 120 * time.Second
 )
+
+var supportedRecordTypes = map[string]bool{
+	"A":     true,
+	"AAAA":  true,
+	"ANY":   true,
+	"CNAME": true,
+	"MX":    true,
+	"NS":    true,
+	"PTR":   true,
+	"SOA":   true,
+	"SRV":   true,
+	"TXT":   true,
+}
 
 // podExecutor interface abstracts pod lifecycle operations for testability.
 type podExecutor interface {
@@ -168,8 +182,9 @@ func makeExecDNSInPodHandler(executor podExecutor) api.ToolHandlerFunc {
 		if !ok || recordType == "" {
 			recordType = "A"
 		}
-		if strings.ContainsAny(recordType, " \t\r\n") || strings.HasPrefix(recordType, "-") || strings.HasPrefix(recordType, "+") || strings.HasPrefix(recordType, "@") {
-			return api.NewToolCallResultStructured(nil, fmt.Errorf("record_type must be a DNS record type, not a dig option")), nil
+		recordType = strings.ToUpper(recordType)
+		if !supportedRecordTypes[recordType] {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("unsupported record_type: %s", recordType)), nil
 		}
 
 		// Use provided executor or create one from the KubernetesClient
@@ -193,6 +208,26 @@ func makeExecDNSInPodHandler(executor podExecutor) api.ToolHandlerFunc {
 						Name:    "dns-probe",
 						Image:   dnsProbeImage,
 						Command: []string{"/usr/bin/dig", fmt.Sprintf("@%s", targetServer), targetName, recordType},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.To(true),
+							AllowPrivilegeEscalation: ptr.To(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
+							},
+						},
 					},
 				},
 			},

--- a/pkg/toolsets/netedge/exec_dns_in_pod.go
+++ b/pkg/toolsets/netedge/exec_dns_in_pod.go
@@ -1,0 +1,229 @@
+package netedge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/google/jsonschema-go/jsonschema"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	dnsProbeImage      = "registry.redhat.io/openshift4/network-tools-rhel9"
+	dnsProbePodPrefix  = "mcp-dns-probe-"
+	dnsProbePollPeriod = 2 * time.Second
+	dnsProbeTimeout    = 120 * time.Second
+)
+
+// podExecutor interface abstracts pod lifecycle operations for testability.
+type podExecutor interface {
+	CreatePod(ctx context.Context, namespace string, pod *corev1.Pod) (*corev1.Pod, error)
+	WaitForPod(ctx context.Context, namespace, name string, timeout time.Duration) (*corev1.Pod, error)
+	GetPodLogs(ctx context.Context, namespace, name string) (string, error)
+	DeletePod(ctx context.Context, namespace, name string) error
+}
+
+// defaultPodExecutor wraps a kubernetes.Interface for real cluster operations.
+type defaultPodExecutor struct {
+	client kubernetes.Interface
+}
+
+func (d *defaultPodExecutor) CreatePod(ctx context.Context, namespace string, pod *corev1.Pod) (*corev1.Pod, error) {
+	return d.client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+}
+
+func (d *defaultPodExecutor) WaitForPod(ctx context.Context, namespace, name string, timeout time.Duration) (*corev1.Pod, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(dnsProbePollPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for pod %s/%s to complete", namespace, name)
+		case <-ticker.C:
+			pod, err := d.client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get pod status: %w", err)
+			}
+			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+				return pod, nil
+			}
+		}
+	}
+}
+
+func (d *defaultPodExecutor) GetPodLogs(ctx context.Context, namespace, name string) (string, error) {
+	req := d.client.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod logs: %w", err)
+	}
+	defer stream.Close() //nolint:errcheck
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, stream); err != nil {
+		return "", fmt.Errorf("failed to read pod logs: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func (d *defaultPodExecutor) DeletePod(ctx context.Context, namespace, name string) error {
+	return d.client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// ExecDNSResult represents the structured JSON response for exec_dns_in_pod.
+type ExecDNSResult struct {
+	PodName string `json:"pod_name"`
+	Output  string `json:"output"`
+	Phase   string `json:"phase"`
+}
+
+func initExecDNSInPod() []api.ServerTool {
+	return initExecDNSInPodWith(nil)
+}
+
+// initExecDNSInPodWith creates exec_dns_in_pod tools using the provided podExecutor.
+// If executor is nil, a defaultPodExecutor is created at handler call-time from the KubernetesClient.
+// Pass a mock executor in tests.
+func initExecDNSInPodWith(executor podExecutor) []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "exec_dns_in_pod",
+				Description: "Spin up a temporary pod in the cluster to execute a DNS lookup using dig, verifying internal cluster networking and DNS path.",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to run the ephemeral pod in.",
+						},
+						"target_server": {
+							Type:        "string",
+							Description: "DNS server IP to query (e.g. 172.30.0.10).",
+						},
+						"target_name": {
+							Type:        "string",
+							Description: "DNS name to query (e.g. kubernetes.default.svc.cluster.local).",
+						},
+						"record_type": {
+							Type:        "string",
+							Description: "DNS record type (A, AAAA, etc.). Defaults to A.",
+							Default:     json.RawMessage(`"A"`),
+						},
+					},
+					Required: []string{"namespace", "target_server", "target_name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Exec DNS in Pod",
+					ReadOnlyHint:    ptr.To(false),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: makeExecDNSInPodHandler(executor),
+		},
+	}
+}
+
+func makeExecDNSInPodHandler(executor podExecutor) api.ToolHandlerFunc {
+	return func(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+		namespace, ok := params.GetArguments()["namespace"].(string)
+		if !ok || namespace == "" {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("namespace parameter is required")), nil
+		}
+
+		targetServer, ok := params.GetArguments()["target_server"].(string)
+		if !ok || targetServer == "" {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("target_server parameter is required")), nil
+		}
+
+		targetName, ok := params.GetArguments()["target_name"].(string)
+		if !ok || targetName == "" {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("target_name parameter is required")), nil
+		}
+
+		recordType, ok := params.GetArguments()["record_type"].(string)
+		if !ok || recordType == "" {
+			recordType = "A"
+		}
+
+		// Use provided executor or create one from the KubernetesClient
+		exec := executor
+		if exec == nil {
+			exec = &defaultPodExecutor{client: params.KubernetesClient}
+		}
+
+		podName := dnsProbePodPrefix + rand.String(6)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{
+					{
+						Name:    "dns-probe",
+						Image:   dnsProbeImage,
+						Command: []string{"/usr/bin/dig", fmt.Sprintf("@%s", targetServer), targetName, recordType},
+					},
+				},
+			},
+		}
+
+		createdPod, err := exec.CreatePod(params.Context, namespace, pod)
+		if err != nil {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("failed to create DNS probe pod: %w", err)), nil
+		}
+		podName = createdPod.Name
+
+		// Always attempt cleanup
+		defer func() {
+			// Use a background context for cleanup since the original context may be cancelled
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			_ = exec.DeletePod(cleanupCtx, namespace, podName)
+		}()
+
+		completedPod, err := exec.WaitForPod(params.Context, namespace, podName, dnsProbeTimeout)
+		if err != nil {
+			return api.NewToolCallResultStructured(nil, fmt.Errorf("error waiting for DNS probe pod: %w", err)), nil
+		}
+
+		phase := string(completedPod.Status.Phase)
+
+		logs, err := exec.GetPodLogs(params.Context, namespace, podName)
+		if err != nil {
+			// Return what we have even if log retrieval fails
+			result := ExecDNSResult{
+				PodName: podName,
+				Output:  fmt.Sprintf("failed to retrieve pod logs: %v", err),
+				Phase:   phase,
+			}
+			return api.NewToolCallResultStructured(result, nil), nil
+		}
+
+		result := ExecDNSResult{
+			PodName: podName,
+			Output:  logs,
+			Phase:   phase,
+		}
+
+		return api.NewToolCallResultStructured(result, nil), nil
+	}
+}

--- a/pkg/toolsets/netedge/exec_dns_in_pod_test.go
+++ b/pkg/toolsets/netedge/exec_dns_in_pod_test.go
@@ -1,0 +1,338 @@
+package netedge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mockPodExecutor struct {
+	createdPod *corev1.Pod
+	createErr  error
+
+	waitPod *corev1.Pod
+	waitErr error
+
+	logs   string
+	logErr error
+
+	deleteErr error
+
+	// Captures for assertions
+	lastNamespace string
+	lastPodName   string
+	lastPod       *corev1.Pod
+	deleteCalled  bool
+}
+
+func (m *mockPodExecutor) CreatePod(_ context.Context, namespace string, pod *corev1.Pod) (*corev1.Pod, error) {
+	m.lastNamespace = namespace
+	m.lastPod = pod
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	if m.createdPod != nil {
+		return m.createdPod, nil
+	}
+	// Return the input pod with phase Pending as default
+	created := pod.DeepCopy()
+	created.Status.Phase = corev1.PodPending
+	return created, nil
+}
+
+func (m *mockPodExecutor) WaitForPod(_ context.Context, _ string, name string, _ time.Duration) (*corev1.Pod, error) {
+	m.lastPodName = name
+	if m.waitErr != nil {
+		return nil, m.waitErr
+	}
+	return m.waitPod, nil
+}
+
+func (m *mockPodExecutor) GetPodLogs(_ context.Context, _ string, name string) (string, error) {
+	m.lastPodName = name
+	if m.logErr != nil {
+		return "", m.logErr
+	}
+	return m.logs, nil
+}
+
+func (m *mockPodExecutor) DeletePod(_ context.Context, _ string, _ string) error {
+	m.deleteCalled = true
+	return m.deleteErr
+}
+
+func succeededPod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}
+}
+
+func failedPod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}
+}
+
+const sampleDigOutput = `; <<>> DiG 9.16.23 <<>> @172.30.0.10 kubernetes.default.svc.cluster.local A
+;; ANSWER SECTION:
+kubernetes.default.svc.cluster.local. 30 IN A 172.30.0.1
+
+;; Query time: 1 msec
+;; SERVER: 172.30.0.10#53(172.30.0.10)
+`
+
+func (s *NetEdgeTestSuite) TestExecDNSInPodHandler() {
+	s.Run("success query", func() {
+		mock := &mockPodExecutor{
+			waitPod: succeededPod("mcp-dns-probe-abc123", "test-ns"),
+			logs:    sampleDigOutput,
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "kubernetes.default.svc.cluster.local",
+			"record_type":   "A",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NoError(result.Error)
+
+		var res ExecDNSResult
+		jsonErr := json.Unmarshal([]byte(result.Content), &res)
+		s.Require().NoError(jsonErr)
+		s.Assert().Equal("Succeeded", res.Phase)
+		s.Assert().Contains(res.Output, "172.30.0.1")
+		s.Assert().NotEmpty(res.PodName)
+
+		structured, ok := result.StructuredContent.(ExecDNSResult)
+		s.Require().True(ok)
+		s.Assert().Equal("Succeeded", structured.Phase)
+		s.Assert().True(mock.deleteCalled, "pod should be cleaned up")
+	})
+
+	s.Run("missing namespace parameter", func() {
+		mock := &mockPodExecutor{}
+		s.SetArgs(map[string]interface{}{
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NotNil(result.Error)
+		s.Assert().Contains(result.Error.Error(), "namespace parameter is required")
+	})
+
+	s.Run("missing target_server parameter", func() {
+		mock := &mockPodExecutor{}
+		s.SetArgs(map[string]interface{}{
+			"namespace":   "test-ns",
+			"target_name": "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NotNil(result.Error)
+		s.Assert().Contains(result.Error.Error(), "target_server parameter is required")
+	})
+
+	s.Run("missing target_name parameter", func() {
+		mock := &mockPodExecutor{}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NotNil(result.Error)
+		s.Assert().Contains(result.Error.Error(), "target_name parameter is required")
+	})
+
+	s.Run("default record_type is A", func() {
+		mock := &mockPodExecutor{
+			waitPod: succeededPod("mcp-dns-probe-abc123", "test-ns"),
+			logs:    sampleDigOutput,
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "kubernetes.default.svc.cluster.local",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NoError(result.Error)
+
+		// Verify the pod command includes "A" as the record type
+		s.Require().NotNil(mock.lastPod)
+		s.Require().Len(mock.lastPod.Spec.Containers, 1)
+		cmd := mock.lastPod.Spec.Containers[0].Command
+		s.Assert().Equal("A", cmd[len(cmd)-1])
+	})
+
+	s.Run("pod creation failure", func() {
+		mock := &mockPodExecutor{
+			createErr: fmt.Errorf("forbidden: namespace test-ns not found"),
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NotNil(result.Error)
+		s.Assert().Contains(result.Error.Error(), "failed to create DNS probe pod")
+		s.Assert().Contains(result.Error.Error(), "namespace test-ns not found")
+	})
+
+	s.Run("pod wait timeout", func() {
+		mock := &mockPodExecutor{
+			waitErr: fmt.Errorf("timed out waiting for pod test-ns/mcp-dns-probe-abc123 to complete"),
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NotNil(result.Error)
+		s.Assert().Contains(result.Error.Error(), "error waiting for DNS probe pod")
+	})
+
+	s.Run("pod fails with Failed phase", func() {
+		mock := &mockPodExecutor{
+			waitPod: failedPod("mcp-dns-probe-abc123", "test-ns"),
+			logs:    "dig: command failed",
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NoError(result.Error)
+
+		var res ExecDNSResult
+		jsonErr := json.Unmarshal([]byte(result.Content), &res)
+		s.Require().NoError(jsonErr)
+		s.Assert().Equal("Failed", res.Phase)
+		s.Assert().Contains(res.Output, "command failed")
+	})
+
+	s.Run("log retrieval failure returns partial result", func() {
+		mock := &mockPodExecutor{
+			waitPod: succeededPod("mcp-dns-probe-abc123", "test-ns"),
+			logErr:  fmt.Errorf("container not found"),
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		// Log retrieval failure should NOT be a protocol error
+		s.Require().NoError(result.Error)
+
+		var res ExecDNSResult
+		jsonErr := json.Unmarshal([]byte(result.Content), &res)
+		s.Require().NoError(jsonErr)
+		s.Assert().Equal("Succeeded", res.Phase)
+		s.Assert().Contains(res.Output, "failed to retrieve pod logs")
+	})
+
+	s.Run("cleanup failure does not affect result", func() {
+		mock := &mockPodExecutor{
+			waitPod:   succeededPod("mcp-dns-probe-abc123", "test-ns"),
+			logs:      sampleDigOutput,
+			deleteErr: fmt.Errorf("delete permission denied"),
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NoError(result.Error)
+
+		var res ExecDNSResult
+		jsonErr := json.Unmarshal([]byte(result.Content), &res)
+		s.Require().NoError(jsonErr)
+		s.Assert().Equal("Succeeded", res.Phase)
+		s.Assert().Contains(res.Output, "172.30.0.1")
+		s.Assert().True(mock.deleteCalled)
+	})
+
+	s.Run("correct pod spec is constructed", func() {
+		mock := &mockPodExecutor{
+			waitPod: succeededPod("mcp-dns-probe-abc123", "my-namespace"),
+			logs:    sampleDigOutput,
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "my-namespace",
+			"target_server": "10.0.0.10",
+			"target_name":   "myservice.default.svc.cluster.local",
+			"record_type":   "AAAA",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		_, err := handler(s.params)
+		s.Require().NoError(err)
+
+		s.Require().NotNil(mock.lastPod)
+		s.Assert().Equal("my-namespace", mock.lastNamespace)
+		s.Assert().Equal(corev1.RestartPolicyNever, mock.lastPod.Spec.RestartPolicy)
+		s.Require().Len(mock.lastPod.Spec.Containers, 1)
+
+		container := mock.lastPod.Spec.Containers[0]
+		s.Assert().Equal(dnsProbeImage, container.Image)
+		s.Assert().Equal([]string{"/usr/bin/dig", "@10.0.0.10", "myservice.default.svc.cluster.local", "AAAA"}, container.Command)
+	})
+}

--- a/pkg/toolsets/netedge/exec_dns_in_pod_test.go
+++ b/pkg/toolsets/netedge/exec_dns_in_pod_test.go
@@ -335,4 +335,97 @@ func (s *NetEdgeTestSuite) TestExecDNSInPodHandler() {
 		s.Assert().Equal(dnsProbeImage, container.Image)
 		s.Assert().Equal([]string{"/usr/bin/dig", "@10.0.0.10", "myservice.default.svc.cluster.local", "AAAA"}, container.Command)
 	})
+
+	s.Run("pod spec disables service account token mount", func() {
+		mock := &mockPodExecutor{
+			waitPod: succeededPod("mcp-dns-probe-abc123", "test-ns"),
+			logs:    sampleDigOutput,
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		_, err := handler(s.params)
+		s.Require().NoError(err)
+
+		s.Require().NotNil(mock.lastPod)
+		s.Require().NotNil(mock.lastPod.Spec.AutomountServiceAccountToken)
+		s.Assert().False(*mock.lastPod.Spec.AutomountServiceAccountToken, "SA token should not be mounted")
+	})
+
+	s.Run("rejects non-IP target_server", func() {
+		mock := &mockPodExecutor{}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "not-an-ip",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		result, err := handler(s.params)
+
+		s.Require().NoError(err)
+		s.Require().NotNil(result.Error)
+		s.Assert().Contains(result.Error.Error(), "target_server must be a valid IP address")
+	})
+
+	s.Run("rejects option-shaped target_name", func() {
+		testCases := []struct {
+			name       string
+			targetName string
+		}{
+			{"dash prefix", "-f /etc/hostname"},
+			{"plus prefix", "+trace"},
+			{"at prefix", "@8.8.8.8"},
+		}
+		for _, tc := range testCases {
+			s.Run(tc.name, func() {
+				mock := &mockPodExecutor{}
+				s.SetArgs(map[string]interface{}{
+					"namespace":     "test-ns",
+					"target_server": "172.30.0.10",
+					"target_name":   tc.targetName,
+				})
+				handler := makeExecDNSInPodHandler(mock)
+
+				result, err := handler(s.params)
+
+				s.Require().NoError(err)
+				s.Require().NotNil(result.Error)
+				s.Assert().Contains(result.Error.Error(), "target_name must be a DNS name")
+			})
+		}
+	})
+
+	s.Run("rejects option-shaped record_type", func() {
+		testCases := []struct {
+			name       string
+			recordType string
+		}{
+			{"dash prefix", "-f"},
+			{"plus prefix", "+short"},
+			{"at prefix", "@server"},
+		}
+		for _, tc := range testCases {
+			s.Run(tc.name, func() {
+				mock := &mockPodExecutor{}
+				s.SetArgs(map[string]interface{}{
+					"namespace":     "test-ns",
+					"target_server": "172.30.0.10",
+					"target_name":   "example.com",
+					"record_type":   tc.recordType,
+				})
+				handler := makeExecDNSInPodHandler(mock)
+
+				result, err := handler(s.params)
+
+				s.Require().NoError(err)
+				s.Require().NotNil(result.Error)
+				s.Assert().Contains(result.Error.Error(), "record_type must be a DNS record type")
+			})
+		}
+	})
 }

--- a/pkg/toolsets/netedge/exec_dns_in_pod_test.go
+++ b/pkg/toolsets/netedge/exec_dns_in_pod_test.go
@@ -400,7 +400,7 @@ func (s *NetEdgeTestSuite) TestExecDNSInPodHandler() {
 		}
 	})
 
-	s.Run("rejects option-shaped record_type", func() {
+	s.Run("rejects unsupported record_type", func() {
 		testCases := []struct {
 			name       string
 			recordType string
@@ -408,6 +408,7 @@ func (s *NetEdgeTestSuite) TestExecDNSInPodHandler() {
 			{"dash prefix", "-f"},
 			{"plus prefix", "+short"},
 			{"at prefix", "@server"},
+			{"unknown type", "UNKNOWN"},
 		}
 		for _, tc := range testCases {
 			s.Run(tc.name, func() {
@@ -424,8 +425,39 @@ func (s *NetEdgeTestSuite) TestExecDNSInPodHandler() {
 
 				s.Require().NoError(err)
 				s.Require().NotNil(result.Error)
-				s.Assert().Contains(result.Error.Error(), "record_type must be a DNS record type")
+				s.Assert().Contains(result.Error.Error(), "unsupported record_type")
 			})
 		}
+	})
+
+	s.Run("pod spec includes security context and resources", func() {
+		mock := &mockPodExecutor{
+			waitPod: succeededPod("mcp-dns-probe-abc123", "test-ns"),
+			logs:    sampleDigOutput,
+		}
+		s.SetArgs(map[string]interface{}{
+			"namespace":     "test-ns",
+			"target_server": "172.30.0.10",
+			"target_name":   "example.com",
+		})
+		handler := makeExecDNSInPodHandler(mock)
+
+		_, err := handler(s.params)
+		s.Require().NoError(err)
+
+		s.Require().NotNil(mock.lastPod)
+		s.Require().Len(mock.lastPod.Spec.Containers, 1)
+		container := mock.lastPod.Spec.Containers[0]
+
+		s.Require().NotNil(container.SecurityContext)
+		s.Assert().True(*container.SecurityContext.RunAsNonRoot)
+		s.Assert().False(*container.SecurityContext.AllowPrivilegeEscalation)
+		s.Require().NotNil(container.SecurityContext.Capabilities)
+		s.Assert().Contains(container.SecurityContext.Capabilities.Drop, corev1.Capability("ALL"))
+
+		s.Assert().False(container.Resources.Requests.Cpu().IsZero())
+		s.Assert().False(container.Resources.Requests.Memory().IsZero())
+		s.Assert().False(container.Resources.Limits.Cpu().IsZero())
+		s.Assert().False(container.Resources.Limits.Memory().IsZero())
 	})
 }

--- a/pkg/toolsets/netedge/toolset.go
+++ b/pkg/toolsets/netedge/toolset.go
@@ -29,6 +29,7 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 		initProbeDNSLocal(),
 		initProbeHTTP(),
 		initRoutes(),
+		initExecDNSInPod(),
 	)
 }
 


### PR DESCRIPTION
This PR implements in-cluster DNS probing via ephemeral pods: `exec_dns_in_pod` ([NE-2453](https://issues.redhat.com/browse/NE-2453))

- Description: Spin up a temporary pod in the cluster to execute a DNS lookup using `dig`, verifying internal cluster networking and DNS path.
- It uses `client-go` to create a Pod with the `registry.redhat.io/openshift4/network-tools-rhel9` image.
- It uses a `podExecutor` interface for testability (mock injection in tests, real `kubernetes.Interface` in production).
- Pod lifecycle: create → wait for Succeeded/Failed → retrieve logs → delete (best-effort cleanup).
- Returns structured JSON: `pod_name`, `output` (raw dig output), `phase` (Succeeded/Failed).
- 11 unit tests covering success, parameter validation, pod lifecycle failures, and cleanup.

Fixes [NE-2453](https://issues.redhat.com/browse/NE-2453): https://issues.redhat.com/browse/NE-2453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DNS query tool that runs dig inside an ephemeral in-cluster pod to query a specified server/name (default record type A), returning pod name, query output, and pod status.
  * Input validation for server/name/record type and hardened probe execution with enforced resource/security settings and guaranteed cleanup attempts.
* **Tests**
  * Added comprehensive tests covering success, validation errors, pod failures, log retrieval issues, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->