### PR TITLE
NO-JIRA: fix(helm): image has correct type for tag

### DIFF
--- a/charts/openshift-mcp-server/values-openshift.yaml
+++ b/charts/openshift-mcp-server/values-openshift.yaml
@@ -13,7 +13,7 @@ openshift: true
 image:
   registry: registry.redhat.io
   repository: openshift-mcp-beta/openshift-mcp-server-rhel9
-  version: 0.2
+  version: "0.2"
 
 # -- RBAC configuration for ACM (Advanced Cluster Management) provider.
 # -- These permissions are the minimum required for the ACM hub provider to function.

--- a/charts/openshift-mcp-server/values.yaml
+++ b/charts/openshift-mcp-server/values.yaml
@@ -9,7 +9,7 @@ image:
   registry: registry.redhat.io
   repository: openshift-mcp-beta/openshift-mcp-server-rhel9
   # -- This sets the tag or sha digest for the image.
-  version: 0.2
+  version: "0.2"
   # -- This sets the pull policy for images.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The helm chart currently fails to install because the image tag is unmarshalled as a number, not a string