### PR TITLE
OCPMCP-242: feat(core): specify model should set SecurityContext on pods

### DIFF
--- a/pkg/config/config_default_overrides.go
+++ b/pkg/config/config_default_overrides.go
@@ -6,5 +6,14 @@ func defaultOverrides() StaticConfig {
 		// For current release we want to just expose the settings below:
 		ReadOnly: true,
 		Toolsets: []string{"core", "config"},
+		ToolOverrides: map[string]ToolOverride{
+			"resources_create_or_update": {
+				Description: "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource.\n" +
+					"IMPORTANT: For Pod resources, you MUST set spec.securityContext and spec.containers[*].securityContext. " +
+					"For workload resources (Deployment, StatefulSet, Job), you MUST set spec.template.spec.securityContext and spec.template.spec.containers[*].securityContext. " +
+					"Use a non-root security context: set runAsNonRoot: true, allowPrivilegeEscalation: false, and drop ALL capabilities (capabilities: {drop: [\"ALL\"]}). " +
+					"Omitting the SecurityContext will cause pod scheduling failures on OpenShift and other clusters that enforce restricted security policies.",
+			},
+		},
 	}
 }


### PR DESCRIPTION
We noticed a divergence in downstream eval results because the model did not set the SecurityContext. This PR updates the tool override to do so properly.

Note: this needs https://github.com/containers/kubernetes-mcp-server/pull/1040 to be in place (and synced downstream), otherwise tests will fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed guidance for the resources_create_or_update tool describing required Pod and container securityContext settings (run as non-root, disallow privilege escalation, drop all capabilities). These instructions explain how to format securityContext in resource manifests to avoid pod scheduling failures on clusters enforcing restricted PodSecurity policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->