### PR TITLE
OCPMCP-238: feat(http): skip auth on tools/list calls

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,6 +138,14 @@ type StaticConfig struct {
 	// Defaults to false.
 	ValidationEnabled bool `toml:"validation_enabled,omitempty"`
 
+	// ExperimentalSkipToolListAuth skips OAuth validation for MCP tools/list
+	// requests on the StreamableHTTP transport (/mcp endpoint).
+	// This is intended for gateway integrations where the gateway cannot set
+	// auth headers on tool discovery requests.
+	// No auth context is injected — tool calls still require authentication.
+	// Defaults to false.
+	ExperimentalSkipToolListAuth bool `toml:"experimental_skip_tool_list_auth,omitempty"`
+
 	// ConfirmationFallback is the global default fallback behavior when a client
 	// does not support elicitation. Valid values are "deny" and "allow".
 	ConfirmationFallback string `toml:"confirmation_fallback,omitempty"`

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -1,8 +1,11 @@
 package http
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"slices"
 	"strings"
@@ -16,6 +19,47 @@ import (
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 )
+
+// mcpJSONRPCRequest contains only the fields needed to identify a tools/list
+// request. ID uses json.RawMessage so we can distinguish "present" (request)
+// from "absent" (notification).
+type mcpJSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	ID      json.RawMessage `json:"id"`
+}
+
+// isToolsListRequest checks whether the request body is a single JSON-RPC
+// tools/list request. It always restores r.Body so downstream handlers can
+// read the full payload regardless of the outcome.
+// Body size is expected to already be bounded by MaxBodyMiddleware.
+func isToolsListRequest(r *http.Request) bool {
+	if r.Body == nil || r.Body == http.NoBody {
+		return false
+	}
+
+	buf, err := io.ReadAll(r.Body)
+	// Restore the body from the buffer so downstream handlers can read it.
+	r.Body = io.NopCloser(bytes.NewReader(buf))
+	if err != nil {
+		return false
+	}
+
+	// Reject batched requests (JSON arrays) and empty/malformed bodies.
+	trimmed := bytes.TrimLeft(buf, " \t\r\n")
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false
+	}
+
+	var msg mcpJSONRPCRequest
+	if err := json.Unmarshal(buf, &msg); err != nil {
+		return false
+	}
+
+	return msg.JSONRPC == "2.0" &&
+		msg.Method == "tools/list" &&
+		len(msg.ID) > 0 && string(msg.ID) != "null"
+}
 
 // write401 sends a 401/Unauthorized response with WWW-Authenticate header.
 func write401(w http.ResponseWriter, wwwAuthenticateHeader, errorType, message string) {
@@ -64,6 +108,17 @@ func AuthorizationMiddleware(staticConfig *config.StaticConfig, oauthState *oaut
 				return
 			}
 			if !staticConfig.RequireOAuth {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Skip auth for tools/list requests on the StreamableHTTP endpoint
+			// when configured. No auth context is injected — tool calls still
+			// require authentication.
+			if staticConfig.ExperimentalSkipToolListAuth &&
+				r.Method == http.MethodPost && r.URL.Path == mcpEndpoint &&
+				isToolsListRequest(r) {
+				klog.V(3).Infof("Skipping auth for tools/list request: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/pkg/http/authorization_skip_tool_list_test.go
+++ b/pkg/http/authorization_skip_tool_list_test.go
@@ -1,0 +1,237 @@
+package http
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+)
+
+type IsToolsListRequestSuite struct {
+	suite.Suite
+}
+
+func (s *IsToolsListRequestSuite) newRequest(body string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString(body))
+	return r
+}
+
+func (s *IsToolsListRequestSuite) TestValidToolsListRequest() {
+	s.Run("minimal request", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+		s.True(isToolsListRequest(r))
+	})
+	s.Run("with string id", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"tools/list","id":"abc"}`)
+		s.True(isToolsListRequest(r))
+	})
+	s.Run("with params cursor", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"tools/list","id":1,"params":{"cursor":"next"}}`)
+		s.True(isToolsListRequest(r))
+	})
+	s.Run("with empty params", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"tools/list","id":1,"params":{}}`)
+		s.True(isToolsListRequest(r))
+	})
+}
+
+func (s *IsToolsListRequestSuite) TestRejectsNonToolsListMethods() {
+	s.Run("tools/call", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"foo"}}`)
+		s.False(isToolsListRequest(r))
+	})
+	s.Run("initialize", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"initialize","id":1}`)
+		s.False(isToolsListRequest(r))
+	})
+	s.Run("resources/read", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"resources/read","id":1}`)
+		s.False(isToolsListRequest(r))
+	})
+}
+
+func (s *IsToolsListRequestSuite) TestRejectsNotifications() {
+	s.Run("missing id", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"tools/list"}`)
+		s.False(isToolsListRequest(r))
+	})
+	s.Run("null id", func() {
+		r := s.newRequest(`{"jsonrpc":"2.0","method":"tools/list","id":null}`)
+		s.False(isToolsListRequest(r))
+	})
+}
+
+func (s *IsToolsListRequestSuite) TestRejectsBatchedRequests() {
+	r := s.newRequest(`[{"jsonrpc":"2.0","method":"tools/list","id":1},{"jsonrpc":"2.0","method":"tools/call","id":2}]`)
+	s.False(isToolsListRequest(r))
+}
+
+func (s *IsToolsListRequestSuite) TestRejectsInvalidJSON() {
+	s.Run("malformed json", func() {
+		r := s.newRequest(`{not valid json}`)
+		s.False(isToolsListRequest(r))
+	})
+	s.Run("empty body", func() {
+		r := s.newRequest(``)
+		s.False(isToolsListRequest(r))
+	})
+	s.Run("whitespace only", func() {
+		r := s.newRequest(`   `)
+		s.False(isToolsListRequest(r))
+	})
+}
+
+func (s *IsToolsListRequestSuite) TestRejectsWrongJSONRPCVersion() {
+	r := s.newRequest(`{"jsonrpc":"1.0","method":"tools/list","id":1}`)
+	s.False(isToolsListRequest(r))
+}
+
+func (s *IsToolsListRequestSuite) TestNilBody() {
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	r.Body = nil
+	s.False(isToolsListRequest(r))
+}
+
+func (s *IsToolsListRequestSuite) TestNoBody() {
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	r.Body = http.NoBody
+	s.False(isToolsListRequest(r))
+}
+
+func (s *IsToolsListRequestSuite) TestBodyRestoredAfterCheck() {
+	original := `{"jsonrpc":"2.0","method":"tools/list","id":1}`
+	s.Run("body restored when true", func() {
+		r := s.newRequest(original)
+		s.True(isToolsListRequest(r))
+		restored, err := io.ReadAll(r.Body)
+		s.NoError(err)
+		s.Equal(original, string(restored))
+	})
+	s.Run("body restored when false", func() {
+		body := `{"jsonrpc":"2.0","method":"tools/call","id":1}`
+		r := s.newRequest(body)
+		s.False(isToolsListRequest(r))
+		restored, err := io.ReadAll(r.Body)
+		s.NoError(err)
+		s.Equal(body, string(restored))
+	})
+}
+
+func TestIsToolsListRequest(t *testing.T) {
+	suite.Run(t, new(IsToolsListRequestSuite))
+}
+
+// SkipToolListAuthSuite tests the full middleware integration with
+// experimental_skip_tool_list_auth enabled.
+type SkipToolListAuthSuite struct {
+	BaseHttpSuite
+}
+
+func (s *SkipToolListAuthSuite) SetupTest() {
+	s.BaseHttpSuite.SetupTest()
+	s.OidcProvider = nil
+	s.StaticConfig.RequireOAuth = true
+	s.StaticConfig.ExperimentalSkipToolListAuth = true
+}
+
+func (s *SkipToolListAuthSuite) TearDownTest() {
+	s.BaseHttpSuite.TearDownTest()
+}
+
+func (s *SkipToolListAuthSuite) TestToolsListWithoutAuth() {
+	s.StartServer()
+	endpoint := fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port)
+
+	s.Run("tools/list succeeds without auth header", func() {
+		body := bytes.NewBufferString(`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+		req, err := http.NewRequest(http.MethodPost, endpoint, body)
+		s.Require().NoError(err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		s.Require().NoError(err)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+		s.NotEqual(http.StatusUnauthorized, resp.StatusCode, "tools/list should bypass auth")
+	})
+}
+
+func (s *SkipToolListAuthSuite) TestToolsCallStillRequiresAuth() {
+	s.StartServer()
+	endpoint := fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port)
+
+	s.Run("tools/call without auth header returns 401", func() {
+		body := bytes.NewBufferString(`{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"events_list"}}`)
+		req, err := http.NewRequest(http.MethodPost, endpoint, body)
+		s.Require().NoError(err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		s.Require().NoError(err)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+		s.Equal(http.StatusUnauthorized, resp.StatusCode, "tools/call must still require auth")
+	})
+}
+
+func (s *SkipToolListAuthSuite) TestInitializeStillRequiresAuth() {
+	s.StartServer()
+	endpoint := fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port)
+
+	s.Run("initialize without auth header returns 401", func() {
+		body := bytes.NewBufferString(`{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`)
+		req, err := http.NewRequest(http.MethodPost, endpoint, body)
+		s.Require().NoError(err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		s.Require().NoError(err)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+		s.Equal(http.StatusUnauthorized, resp.StatusCode, "initialize must still require auth")
+	})
+}
+
+func (s *SkipToolListAuthSuite) TestFlagDisabledStillRequiresAuth() {
+	s.StaticConfig.ExperimentalSkipToolListAuth = false
+	s.StartServer()
+	endpoint := fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port)
+
+	s.Run("tools/list without auth returns 401 when flag is off", func() {
+		body := bytes.NewBufferString(`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+		req, err := http.NewRequest(http.MethodPost, endpoint, body)
+		s.Require().NoError(err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		s.Require().NoError(err)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+		s.Equal(http.StatusUnauthorized, resp.StatusCode, "tools/list must require auth when flag is off")
+	})
+}
+
+func (s *SkipToolListAuthSuite) TestToolsListWithAuthStillWorks() {
+	s.StaticConfig.OAuthAudience = ""
+	s.StartServer()
+	endpoint := fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port)
+
+	options := []test.McpClientOption{
+		test.WithEndpoint(endpoint),
+		test.WithHTTPHeaders(map[string]string{
+			"Authorization": "Bearer " + tokenBasicNotExpired,
+		}),
+	}
+	mcpClient := test.NewMcpClient(s.T(), nil, options...)
+
+	s.Run("authenticated tools/list still succeeds", func() {
+		s.Require().NotNil(mcpClient.Session, "Expected session for successful authentication")
+		tools, err := mcpClient.Session.ListTools(s.T().Context(), &mcp.ListToolsParams{})
+		s.Require().NoError(err, "Expected no error listing tools")
+		s.Greater(len(tools.Tools), 0, "Expected at least one tool")
+	})
+	mcpClient.Close()
+}
+
+func TestSkipToolListAuth(t *testing.T) {
+	suite.Run(t, new(SkipToolListAuthSuite))
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -107,8 +107,8 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.Stat
 	mux := http.NewServeMux()
 
 	wrappedMux := RequestMiddleware(staticConfig.TrustProxyHeaders)(
-		AuthorizationMiddleware(staticConfig, oauthState)(
-			MaxBodyMiddleware(staticConfig.HTTP.MaxBodyBytes)(mux),
+		MaxBodyMiddleware(staticConfig.HTTP.MaxBodyBytes)(
+			AuthorizationMiddleware(staticConfig, oauthState)(mux),
 		),
 	)
 


### PR DESCRIPTION
This PR adds a new config option `experimental_skip_tool_list_auth` which alls the tools/list calls to not have auth applied to them

This is required for the gateway integration to work without giving a long lasting credential to the gateway