### PR TITLE
NO-JIRA: [release-0.3] feat: add e2e smoke test for MCP Lifecycle Operator integration

### DIFF
--- a/build/openshift/e2e.mk
+++ b/build/openshift/e2e.mk
@@ -1,0 +1,56 @@
+##@ E2E Tests
+
+E2E_NAMESPACE ?= openshift-mcp-server-e2e
+MCP_LIFECYCLE_OPERATOR_VERSION ?= v0.1.0
+MCP_LIFECYCLE_OPERATOR_URL ?= https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/download/$(MCP_LIFECYCLE_OPERATOR_VERSION)/install.yaml
+MCP_SERVER_IMAGE ?= quay.io/redhat-user-workloads/ocp-mcp-server-tenant/openshift-mcp-server-release-03:latest
+
+.PHONY: e2e-install-operator
+e2e-install-operator: ## Install the MCP Lifecycle Operator from upstream release
+	@echo "Installing MCP Lifecycle Operator $(MCP_LIFECYCLE_OPERATOR_VERSION)..."
+	kubectl apply -f $(MCP_LIFECYCLE_OPERATOR_URL)
+	@echo "Waiting for operator deployment to be available..."
+	kubectl wait deployment -n mcp-lifecycle-operator-system \
+		-l control-plane=controller-manager \
+		--for=condition=Available \
+		--timeout=120s
+	@echo "MCP Lifecycle Operator is ready."
+
+.PHONY: e2e-deploy-mcp-server
+e2e-deploy-mcp-server: ## Deploy the MCP server via the MCPServer CRD
+	@echo "Creating e2e namespace and RBAC..."
+	kubectl apply -f hack/e2e/namespace.yaml
+	kubectl apply -f hack/e2e/rbac.yaml
+	kubectl apply -f hack/e2e/config.yaml
+	@echo "Deploying MCPServer CR with image: $(MCP_SERVER_IMAGE)"
+	@sed 's|IMAGE_PLACEHOLDER|$(MCP_SERVER_IMAGE)|g' hack/e2e/mcpserver.yaml | kubectl apply -f -
+	@echo "MCPServer CR applied."
+
+.PHONY: e2e-wait-ready
+e2e-wait-ready: ## Wait for MCP server deployment to become ready
+	@echo "Waiting for MCP server deployment to be available..."
+	@kubectl wait deployment/kubernetes-mcp-server \
+		-n $(E2E_NAMESPACE) \
+		--for=condition=Available \
+		--timeout=180s || { \
+		echo "Deployment not ready. Dumping debug info..."; \
+		echo "--- Pod status ---"; \
+		kubectl get pods -n $(E2E_NAMESPACE) -o wide; \
+		echo "--- Pod describe ---"; \
+		kubectl describe pods -n $(E2E_NAMESPACE); \
+		echo "--- Pod logs ---"; \
+		kubectl logs -n $(E2E_NAMESPACE) -l mcp-server=kubernetes-mcp-server --tail=100; \
+		exit 1; \
+	}
+	@echo "Verifying Service exists..."
+	kubectl get service/kubernetes-mcp-server -n $(E2E_NAMESPACE)
+	@echo "Verifying Service has endpoints..."
+	@EP=$$(kubectl get endpoints/kubernetes-mcp-server -n $(E2E_NAMESPACE) -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null); \
+	if [ -z "$$EP" ]; then \
+		echo "No endpoints found for Service. Dumping debug info..."; \
+		kubectl describe service/kubernetes-mcp-server -n $(E2E_NAMESPACE); \
+		kubectl get endpoints/kubernetes-mcp-server -n $(E2E_NAMESPACE) -o yaml; \
+		kubectl get pods -n $(E2E_NAMESPACE) -o wide; \
+		exit 1; \
+	fi
+	@echo "E2E smoke test passed. MCP server is running and reachable."

--- a/hack/e2e/config.yaml
+++ b/hack/e2e/config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-server-e2e-config
+  namespace: openshift-mcp-server-e2e
+data:
+  config.toml: |
+    log_level = 3
+    port = "8080"
+    read_only = true
+    toolsets = ["core"]

--- a/hack/e2e/mcpserver.yaml
+++ b/hack/e2e/mcpserver.yaml
@@ -1,0 +1,24 @@
+apiVersion: mcp.x-k8s.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: kubernetes-mcp-server
+  namespace: openshift-mcp-server-e2e
+spec:
+  source:
+    type: ContainerImage
+    containerImage:
+      ref: IMAGE_PLACEHOLDER
+  config:
+    port: 8080
+    arguments:
+      - --config
+      - /etc/mcp-config/config.toml
+    storage:
+      - path: /etc/mcp-config
+        source:
+          type: ConfigMap
+          configMap:
+            name: mcp-server-e2e-config
+  runtime:
+    security:
+      serviceAccountName: mcp-server-e2e

--- a/hack/e2e/namespace.yaml
+++ b/hack/e2e/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-mcp-server-e2e

--- a/hack/e2e/rbac.yaml
+++ b/hack/e2e/rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcp-server-e2e
+  namespace: openshift-mcp-server-e2e
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcp-server-e2e-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: mcp-server-e2e
+    namespace: openshift-mcp-server-e2e


### PR DESCRIPTION
Add make targets and manifests to deploy and validate the Kubernetes MCP Server on an OCP cluster via the MCP Lifecycle Operator.

New make targets in build/openshift/e2e.mk:
- e2e-install-operator: installs the MCP Lifecycle Operator v0.1.0
- e2e-deploy-mcp-server: deploys the MCP server via MCPServer CRD
- e2e-wait-ready: validates deployment readiness and service endpoints

Static manifests in hack/e2e/ define the namespace, RBAC, config, and MCPServer CR template with image placeholder for CI injection.