### PR TITLE
NO-JIRA: [release-0.3] feat: add MCP Gateway integration to e2e smoke test

### DIFF
--- a/build/openshift/e2e.mk
+++ b/build/openshift/e2e.mk
@@ -4,6 +4,8 @@ E2E_NAMESPACE ?= openshift-mcp-server-e2e
 MCP_LIFECYCLE_OPERATOR_VERSION ?= v0.1.0
 MCP_LIFECYCLE_OPERATOR_URL ?= https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/download/$(MCP_LIFECYCLE_OPERATOR_VERSION)/install.yaml
 MCP_SERVER_IMAGE ?= quay.io/redhat-user-workloads/ocp-mcp-server-tenant/openshift-mcp-server-release-03:latest
+MCP_GATEWAY_VERSION ?= v0.6.0
+MCP_GATEWAY_INSTALL_URL ?= https://github.com/Kuadrant/mcp-gateway/config/install?ref=$(MCP_GATEWAY_VERSION)
 
 .PHONY: e2e-install-operator
 e2e-install-operator: ## Install the MCP Lifecycle Operator from upstream release
@@ -16,6 +18,24 @@ e2e-install-operator: ## Install the MCP Lifecycle Operator from upstream releas
 		--timeout=120s
 	@echo "MCP Lifecycle Operator is ready."
 
+.PHONY: e2e-install-gateway
+e2e-install-gateway: ## Install the MCP Gateway controller and broker
+	@echo "Installing MCP Gateway $(MCP_GATEWAY_VERSION)..."
+	oc apply -k $(MCP_GATEWAY_INSTALL_URL)
+	@echo "Applying Gateway and ReferenceGrants..."
+	oc apply -f hack/e2e/gateway.yaml
+	@echo "Waiting for mcp-gateway-controller deployment to be available..."
+	oc wait deployment/mcp-gateway-controller \
+		-n mcp-system \
+		--for=condition=Available \
+		--timeout=180s
+	@echo "Waiting for mcp-broker-router deployment to be available..."
+	oc wait deployment/mcp-broker-router \
+		-n mcp-system \
+		--for=condition=Available \
+		--timeout=180s
+	@echo "MCP Gateway is ready."
+
 .PHONY: e2e-deploy-mcp-server
 e2e-deploy-mcp-server: ## Deploy the MCP server via the MCPServer CRD
 	@echo "Creating e2e namespace and RBAC..."
@@ -25,6 +45,14 @@ e2e-deploy-mcp-server: ## Deploy the MCP server via the MCPServer CRD
 	@echo "Deploying MCPServer CR with image: $(MCP_SERVER_IMAGE)"
 	@sed 's|IMAGE_PLACEHOLDER|$(MCP_SERVER_IMAGE)|g' hack/e2e/mcpserver.yaml | oc apply -f -
 	@echo "MCPServer CR applied."
+
+.PHONY: e2e-register-mcp-server
+e2e-register-mcp-server: ## Register the MCP server with the MCP Gateway
+	@echo "Applying HTTPRoute and MCPServerRegistration..."
+	oc apply -f hack/e2e/mcpserver-registration.yaml
+	@echo "Verifying MCPServerRegistration exists..."
+	oc get mcpserverregistration/kubernetes-mcp-server -n $(E2E_NAMESPACE)
+	@echo "MCPServerRegistration applied."
 
 .PHONY: e2e-wait-ready
 e2e-wait-ready: ## Wait for MCP server deployment to become ready
@@ -53,4 +81,80 @@ e2e-wait-ready: ## Wait for MCP server deployment to become ready
 		oc get pods -n $(E2E_NAMESPACE) -o wide; \
 		exit 1; \
 	fi
-	@echo "E2E smoke test passed. MCP server is running and reachable."
+	@echo "Creating Route for direct MCP server access..."
+	oc expose svc/kubernetes-mcp-server -n $(E2E_NAMESPACE)
+	@echo "Sending direct MCP initialize request via Route..."
+	@ROUTE_HOST=$$(oc get route/kubernetes-mcp-server -n $(E2E_NAMESPACE) -o jsonpath='{.spec.host}'); \
+	if [ -z "$$ROUTE_HOST" ]; then \
+		echo "Route has no host assigned."; \
+		oc get route/kubernetes-mcp-server -n $(E2E_NAMESPACE) -o yaml; \
+		exit 1; \
+	fi; \
+	echo "Route host: $$ROUTE_HOST"; \
+	HTTP_CODE=$$(curl -s -o /tmp/mcp-direct.json -w '%{http_code}' --max-time 10 \
+		-X POST "http://$$ROUTE_HOST/mcp" \
+		-H "Content-Type: application/json" \
+		-d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-direct-test","version":"1.0.0"}},"id":1}'); \
+	echo "Direct HTTP status: $$HTTP_CODE"; \
+	cat /tmp/mcp-direct.json 2>/dev/null; echo; \
+	if [ "$$HTTP_CODE" != "200" ]; then \
+		echo "Direct MCP request failed with HTTP $$HTTP_CODE."; \
+		oc logs -n $(E2E_NAMESPACE) -l mcp-server=kubernetes-mcp-server --tail=50; \
+		exit 1; \
+	fi; \
+	if ! grep -q '"result"' /tmp/mcp-direct.json; then \
+		echo "Direct response missing expected 'result' field."; \
+		cat /tmp/mcp-direct.json; \
+		exit 1; \
+	fi
+	@echo "Verifying MCPServerRegistration exists..."
+	oc get mcpserverregistration/kubernetes-mcp-server -n $(E2E_NAMESPACE)
+	@echo "E2E smoke test passed. MCP server is running and reachable via MCP Gateway."
+
+.PHONY: e2e-smoke-test
+e2e-smoke-test: ## Smoke test the MCP server through the MCP Gateway
+	@echo "Retrieving Gateway address..."
+	@GW_HOST=""; \
+	for i in $$(seq 1 30); do \
+		GW_HOST=$$(oc get gateway mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null); \
+		if [ -n "$$GW_HOST" ]; then break; fi; \
+		echo "Waiting for Gateway address... ($$i/30)"; \
+		sleep 5; \
+	done; \
+	if [ -z "$$GW_HOST" ]; then \
+		echo "Gateway did not receive an address."; \
+		oc get gateway mcp-gateway -n gateway-system -o yaml; \
+		exit 1; \
+	fi; \
+	echo "Gateway address: $$GW_HOST"; \
+	echo "Sending MCP initialize request through Gateway..."; \
+	HTTP_CODE=$$(curl -s -o /tmp/mcp-response.json -w '%{http_code}' --max-time 10 \
+		-X POST "http://$$GW_HOST/mcp" \
+		-H "Content-Type: application/json" \
+		-d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-smoke-test","version":"1.0.0"}},"id":1}'); \
+	echo "HTTP status: $$HTTP_CODE"; \
+	cat /tmp/mcp-response.json 2>/dev/null; echo; \
+	if [ "$$HTTP_CODE" != "200" ]; then \
+		echo "Expected HTTP 200, got $$HTTP_CODE. Dumping debug info..."; \
+		echo "--- Gateway status ---"; \
+		oc get gateway mcp-gateway -n gateway-system -o yaml; \
+		echo "--- HTTPRoute status ---"; \
+		oc get httproute kubernetes-mcp-server -n $(E2E_NAMESPACE) -o yaml; \
+		echo "--- MCPServerRegistration ---"; \
+		oc get mcpserverregistration kubernetes-mcp-server -n $(E2E_NAMESPACE) -o yaml; \
+		echo "--- Broker logs ---"; \
+		oc logs -n mcp-system -l app=mcp-broker-router --tail=50; \
+		exit 1; \
+	fi; \
+	if ! grep -q '"result"' /tmp/mcp-response.json; then \
+		echo "Response missing expected 'result' field."; \
+		cat /tmp/mcp-response.json; \
+		exit 1; \
+	fi; \
+	echo "Smoke test passed. MCP server responded through the MCP Gateway."
+
+.PHONY: e2e-setup
+e2e-setup: e2e-install-operator e2e-install-gateway e2e-deploy-mcp-server e2e-register-mcp-server e2e-wait-ready ## Install all components and wait for readiness
+
+.PHONY: e2e-test
+e2e-test: e2e-setup e2e-smoke-test ## Run the full e2e test (setup + smoke tests)

--- a/hack/e2e/gateway.yaml
+++ b/hack/e2e/gateway.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-system
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: mcp-gateway
+  namespace: gateway-system
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+  - name: mcp
+    protocol: HTTP
+    port: 8080
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# Allow MCPGatewayExtension in mcp-system to reference Gateway in gateway-system
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-mcp-gateway-extension
+  namespace: gateway-system
+spec:
+  from:
+  - group: mcp.kuadrant.io
+    kind: MCPGatewayExtension
+    namespace: mcp-system
+  to:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+---
+# Allow HTTPRoutes in e2e namespace to reference Gateway in gateway-system
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-mcp-server-routes
+  namespace: gateway-system
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: openshift-mcp-server-e2e
+  to:
+  - group: gateway.networking.k8s.io
+    kind: Gateway

--- a/hack/e2e/mcpserver-registration.yaml
+++ b/hack/e2e/mcpserver-registration.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubernetes-mcp-server
+  namespace: openshift-mcp-server-e2e
+spec:
+  parentRefs:
+  - name: mcp-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: kubernetes-mcp-server
+      port: 8080
+---
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: kubernetes-mcp-server
+  namespace: openshift-mcp-server-e2e
+spec:
+  toolPrefix: kube_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: kubernetes-mcp-server


### PR DESCRIPTION
Install the Kuadrant MCP Gateway (v0.6.0) via kustomize, create a Gateway resource with openshift-default `gatewayClassName`, and register the MCP server via `HTTPRoute` and `MCPServerRegistration`.

Add a direct smoke test against the MCP server Route and a Gateway smoke test that sends an MCP initialize request through the full Gateway path.

New make targets: `e2e-install-gateway`, `e2e-register-mcp-server` and `e2e-smoke-test`. Updated `e2e-wait-ready` with direct MCP protocol verification via "oc expose route".