### PR TITLE
GIE-506: Bump rhobs/obs-mcp to v0.1.1 and add e2e tests for toolset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ build-all-platforms: clean tidy format lint ## Build the project for all platfor
 test: ## Run the tests
 	go test -count=1 -v ./...
 
+.PHONY: test-observability-e2e
+test-observability-e2e: ## Run obs-mcp e2e tests against an OpenShift cluster
+	go test -tags observability_e2e -count=1 -v ./pkg/observability/tests/
+
 .PHONY: test-update-snapshots
 test-update-snapshots: ## Update test snapshots for toolset tests
 	UPDATE_TOOLSETS_JSON=1 go test -count=1 -v ./pkg/mcp

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/miekg/dns v1.1.68
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/rhobs/obs-mcp v0.1.0
+	github.com/rhobs/obs-mcp v0.1.1
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
-github.com/rhobs/obs-mcp v0.1.0 h1:l/HnMi9+7ytJzVKao6YMHNBciw8cwOz0mVlTZZcR/Eo=
-github.com/rhobs/obs-mcp v0.1.0/go.mod h1:Zuq0El4CL3JEcFCRyKqODua0Fi3LYojljTqQkGGdfJ8=
+github.com/rhobs/obs-mcp v0.1.1 h1:A3Xa9ElwZN2qaf2OSShResgNs0h0ApCPVNctV/z4EQg=
+github.com/rhobs/obs-mcp v0.1.1/go.mod h1:Zuq0El4CL3JEcFCRyKqODua0Fi3LYojljTqQkGGdfJ8=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/pkg/observability/tests/metrics_test.go
+++ b/pkg/observability/tests/metrics_test.go
@@ -56,6 +56,7 @@ type MetricsE2ESuite struct {
 	server          *mcpserver.Server
 	prometheusURL   string
 	alertmanagerURL string
+	testMetric      string
 }
 
 func (s *MetricsE2ESuite) SetupSuite() {
@@ -77,6 +78,49 @@ func (s *MetricsE2ESuite) SetupSuite() {
 	}
 	s.T().Logf("Prometheus URL: %s", s.prometheusURL)
 	s.T().Logf("Alertmanager URL: %s", s.alertmanagerURL)
+
+	// Discover a real metric from the cluster for use in query tests.
+	// This also warms up the Thanos Querier label cache so that
+	// ValidateMetricsExist (which lists all metric names) succeeds
+	// reliably in subsequent per-test calls.
+	s.testMetric = s.discoverTestMetric()
+	s.Require().NotEmpty(s.testMetric, "could not discover any metric from Prometheus")
+	s.T().Logf("Test metric: %s", s.testMetric)
+}
+
+// discoverTestMetric creates a temporary MCP server to call list_metrics
+// and returns the first CPU metric found. This also pre-warms the Thanos
+// Querier's metric name cache.
+func (s *MetricsE2ESuite) discoverTestMetric() string {
+	cfg := s.buildConfig()
+
+	provider, err := internalk8s.NewProvider(cfg)
+	if err != nil {
+		s.T().Logf("Could not create provider for metric discovery: %v", err)
+		return ""
+	}
+
+	server, err := mcpserver.NewServer(mcpserver.Configuration{StaticConfig: cfg}, provider)
+	if err != nil {
+		s.T().Logf("Could not create server for metric discovery: %v", err)
+		return ""
+	}
+	defer server.Close()
+
+	client := test.NewMcpClient(s.T(), server.ServeHTTP())
+	defer client.Close()
+
+	result, err := client.CallTool("list_metrics", map[string]any{"name_regex": ".*cpu.*"})
+	if err != nil || result.IsError {
+		s.T().Logf("list_metrics failed during discovery: err=%v, isError=%v", err, result != nil && result.IsError)
+		return ""
+	}
+
+	var output listMetricsOutput
+	if err := json.Unmarshal([]byte(textContent(result)), &output); err != nil || len(output.Metrics) == 0 {
+		return ""
+	}
+	return output.Metrics[0]
 }
 
 // discoverRoutes reads OpenShift Route objects from the openshift-monitoring
@@ -130,7 +174,7 @@ func (s *MetricsE2ESuite) discoverRoutes() map[string]string {
 	return result
 }
 
-func (s *MetricsE2ESuite) SetupTest() {
+func (s *MetricsE2ESuite) buildConfig() *config.StaticConfig {
 	tomlCfg := fmt.Sprintf(`
 		toolsets = ["metrics"]
 		[toolset_configs.metrics]
@@ -146,6 +190,11 @@ func (s *MetricsE2ESuite) SetupTest() {
 	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
 		cfg.KubeConfig = kubeconfig
 	}
+	return cfg
+}
+
+func (s *MetricsE2ESuite) SetupTest() {
+	cfg := s.buildConfig()
 
 	provider, err := internalk8s.NewProvider(cfg)
 	s.Require().NoError(err, "Failed to create k8s provider")
@@ -180,9 +229,9 @@ func (s *MetricsE2ESuite) TestListMetrics() {
 }
 
 func (s *MetricsE2ESuite) TestExecuteInstantQuery() {
-	s.Run("executes an instant query for up metric", func() {
+	s.Run("executes an instant query", func() {
 		toolResult, err := s.CallTool("execute_instant_query", map[string]any{
-			"query": "up",
+			"query": s.testMetric,
 		})
 		s.Require().NoError(err)
 		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
@@ -190,14 +239,14 @@ func (s *MetricsE2ESuite) TestExecuteInstantQuery() {
 		var output instantQueryOutput
 		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
 		s.Equal("vector", output.ResultType)
-		s.NotEmpty(output.Result, "expected at least one result for 'up' query")
+		s.NotEmpty(output.Result, "expected at least one result")
 	})
 }
 
 func (s *MetricsE2ESuite) TestExecuteRangeQuery() {
 	s.Run("executes a range query with step", func() {
 		toolResult, err := s.CallTool("execute_range_query", map[string]any{
-			"query":    "up",
+			"query":    s.testMetric,
 			"step":     "1m",
 			"duration": "5m",
 		})
@@ -213,10 +262,10 @@ func (s *MetricsE2ESuite) TestExecuteRangeQuery() {
 func (s *MetricsE2ESuite) TestShowTimeseries() {
 	s.Run("validates a range query for chart rendering", func() {
 		toolResult, err := s.CallTool("show_timeseries", map[string]any{
-			"query":    "up",
+			"query":    s.testMetric,
 			"step":     "1m",
 			"duration": "5m",
-			"title":    "Targets Up",
+			"title":    "Test Timeseries",
 		})
 		s.Require().NoError(err)
 		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
@@ -224,43 +273,45 @@ func (s *MetricsE2ESuite) TestShowTimeseries() {
 }
 
 func (s *MetricsE2ESuite) TestGetLabelNames() {
-	s.Run("retrieves label names", func() {
-		toolResult, err := s.CallTool("get_label_names", map[string]any{})
+	s.Run("retrieves label names for a metric", func() {
+		toolResult, err := s.CallTool("get_label_names", map[string]any{
+			"metric": s.testMetric,
+		})
 		s.Require().NoError(err)
 		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
 
 		var output labelNamesOutput
 		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
 		s.NotEmpty(output.Labels, "expected at least one label name")
-		s.Contains(output.Labels, "__name__")
 	})
 }
 
 func (s *MetricsE2ESuite) TestGetLabelValues() {
-	s.Run("retrieves label values for job label", func() {
+	s.Run("retrieves label values for __name__ label", func() {
 		toolResult, err := s.CallTool("get_label_values", map[string]any{
-			"label": "job",
+			"label":  "__name__",
+			"metric": s.testMetric,
 		})
 		s.Require().NoError(err)
 		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
 
 		var output labelValuesOutput
 		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
-		s.NotEmpty(output.Values, "expected at least one job label value")
+		s.NotEmpty(output.Values, "expected at least one label value")
 	})
 }
 
 func (s *MetricsE2ESuite) TestGetSeries() {
-	s.Run("retrieves series for up metric", func() {
+	s.Run("retrieves series for a metric", func() {
 		toolResult, err := s.CallTool("get_series", map[string]any{
-			"matches": "up",
+			"matches": fmt.Sprintf(`{__name__="%s"}`, s.testMetric),
 		})
 		s.Require().NoError(err)
 		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
 
 		var output seriesOutput
 		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
-		s.NotEmpty(output.Series, "expected at least one series for 'up'")
+		s.NotEmpty(output.Series, "expected at least one series")
 		s.Greater(output.Cardinality, 0)
 	})
 }

--- a/pkg/observability/tests/metrics_test.go
+++ b/pkg/observability/tests/metrics_test.go
@@ -1,0 +1,348 @@
+//go:build observability_e2e
+
+package observability
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	mcpserver "github.com/containers/kubernetes-mcp-server/pkg/mcp"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+
+	_ "github.com/rhobs/obs-mcp/pkg/toolset"
+)
+
+const (
+	openshiftMonitoringNS = "openshift-monitoring"
+	thanosQuerierRoute    = "thanos-querier"
+	alertmanagerRoute     = "alertmanager-main"
+)
+
+// MetricsE2ESuite tests the obs-mcp (metrics) toolset against a real
+// OpenShift cluster where Prometheus and Alertmanager are available
+// in the openshift-monitoring namespace.
+//
+// URLs are auto-discovered from OpenShift routes in the openshift-monitoring
+// namespace. Override with PROMETHEUS_URL / ALERTMANAGER_URL env vars if needed.
+//
+// Run with:
+//
+//	make test-observability-e2e
+//
+// Or directly:
+//
+//	go test -tags observability_e2e ./pkg/observability/tests/ -v
+//
+// Optional environment variables:
+//
+//	PROMETHEUS_URL   - Override auto-discovered Prometheus/Thanos Querier URL
+//	ALERTMANAGER_URL - Override auto-discovered Alertmanager URL
+//	KUBECONFIG       - Path to kubeconfig file (defaults to ~/.kube/config)
+type MetricsE2ESuite struct {
+	suite.Suite
+	*test.McpClient
+	server          *mcpserver.Server
+	prometheusURL   string
+	alertmanagerURL string
+}
+
+func (s *MetricsE2ESuite) SetupSuite() {
+	s.prometheusURL = os.Getenv("PROMETHEUS_URL")
+	s.alertmanagerURL = os.Getenv("ALERTMANAGER_URL")
+
+	if s.prometheusURL == "" || s.alertmanagerURL == "" {
+		discovered := s.discoverRoutes()
+		if s.prometheusURL == "" {
+			s.prometheusURL = discovered[thanosQuerierRoute]
+		}
+		if s.alertmanagerURL == "" {
+			s.alertmanagerURL = discovered[alertmanagerRoute]
+		}
+	}
+
+	if s.prometheusURL == "" {
+		s.T().Fatal("Could not determine Prometheus URL: set PROMETHEUS_URL or ensure the thanos-querier route exists in openshift-monitoring")
+	}
+	s.T().Logf("Prometheus URL: %s", s.prometheusURL)
+	s.T().Logf("Alertmanager URL: %s", s.alertmanagerURL)
+}
+
+// discoverRoutes reads OpenShift Route objects from the openshift-monitoring
+// namespace and returns a map of route-name -> URL.
+func (s *MetricsE2ESuite) discoverRoutes() map[string]string {
+	result := make(map[string]string)
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		s.T().Logf("Could not load kubeconfig for route discovery: %v", err)
+		return result
+	}
+
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		s.T().Logf("Could not create dynamic client for route discovery: %v", err)
+		return result
+	}
+
+	routeGVR := schema.GroupVersionResource{
+		Group:    "route.openshift.io",
+		Version:  "v1",
+		Resource: "routes",
+	}
+
+	for _, routeName := range []string{thanosQuerierRoute, alertmanagerRoute} {
+		route, err := dynClient.Resource(routeGVR).Namespace(openshiftMonitoringNS).
+			Get(context.Background(), routeName, metav1.GetOptions{})
+		if err != nil {
+			s.T().Logf("Could not get route %s/%s: %v", openshiftMonitoringNS, routeName, err)
+			continue
+		}
+
+		host, found, _ := unstructured.NestedString(route.Object, "spec", "host")
+		if !found || host == "" {
+			s.T().Logf("Route %s has no spec.host", routeName)
+			continue
+		}
+
+		tls, _, _ := unstructured.NestedString(route.Object, "spec", "tls", "termination")
+		scheme := "http"
+		if tls != "" {
+			scheme = "https"
+		}
+
+		result[routeName] = fmt.Sprintf("%s://%s", scheme, host)
+	}
+
+	return result
+}
+
+func (s *MetricsE2ESuite) SetupTest() {
+	tomlCfg := fmt.Sprintf(`
+		toolsets = ["metrics"]
+		[toolset_configs.metrics]
+		prometheus_url = "%s"
+		alertmanager_url = "%s"
+		insecure = true
+		guardrails = "none"
+	`, s.prometheusURL, s.alertmanagerURL)
+
+	cfg, err := config.ReadToml([]byte(tomlCfg))
+	s.Require().NoError(err, "Failed to parse test config")
+
+	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
+		cfg.KubeConfig = kubeconfig
+	}
+
+	provider, err := internalk8s.NewProvider(cfg)
+	s.Require().NoError(err, "Failed to create k8s provider")
+
+	s.server, err = mcpserver.NewServer(mcpserver.Configuration{StaticConfig: cfg}, provider)
+	s.Require().NoError(err, "Failed to create MCP server")
+
+	s.McpClient = test.NewMcpClient(s.T(), s.server.ServeHTTP())
+}
+
+func (s *MetricsE2ESuite) TearDownTest() {
+	if s.McpClient != nil {
+		s.Close()
+	}
+	if s.server != nil {
+		s.server.Close()
+	}
+}
+
+func (s *MetricsE2ESuite) TestListMetrics() {
+	s.Run("lists metrics matching a regex pattern", func() {
+		toolResult, err := s.CallTool("list_metrics", map[string]any{
+			"name_regex": ".*cpu.*",
+		})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output listMetricsOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.NotEmpty(output.Metrics, "expected at least one CPU metric")
+	})
+}
+
+func (s *MetricsE2ESuite) TestExecuteInstantQuery() {
+	s.Run("executes an instant query for up metric", func() {
+		toolResult, err := s.CallTool("execute_instant_query", map[string]any{
+			"query": "up",
+		})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output instantQueryOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.Equal("vector", output.ResultType)
+		s.NotEmpty(output.Result, "expected at least one result for 'up' query")
+	})
+}
+
+func (s *MetricsE2ESuite) TestExecuteRangeQuery() {
+	s.Run("executes a range query with step", func() {
+		toolResult, err := s.CallTool("execute_range_query", map[string]any{
+			"query":    "up",
+			"step":     "1m",
+			"duration": "5m",
+		})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output rangeQueryOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.Equal("matrix", output.ResultType)
+	})
+}
+
+func (s *MetricsE2ESuite) TestShowTimeseries() {
+	s.Run("validates a range query for chart rendering", func() {
+		toolResult, err := s.CallTool("show_timeseries", map[string]any{
+			"query":    "up",
+			"step":     "1m",
+			"duration": "5m",
+			"title":    "Targets Up",
+		})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+	})
+}
+
+func (s *MetricsE2ESuite) TestGetLabelNames() {
+	s.Run("retrieves label names", func() {
+		toolResult, err := s.CallTool("get_label_names", map[string]any{})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output labelNamesOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.NotEmpty(output.Labels, "expected at least one label name")
+		s.Contains(output.Labels, "__name__")
+	})
+}
+
+func (s *MetricsE2ESuite) TestGetLabelValues() {
+	s.Run("retrieves label values for job label", func() {
+		toolResult, err := s.CallTool("get_label_values", map[string]any{
+			"label": "job",
+		})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output labelValuesOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.NotEmpty(output.Values, "expected at least one job label value")
+	})
+}
+
+func (s *MetricsE2ESuite) TestGetSeries() {
+	s.Run("retrieves series for up metric", func() {
+		toolResult, err := s.CallTool("get_series", map[string]any{
+			"matches": "up",
+		})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output seriesOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.NotEmpty(output.Series, "expected at least one series for 'up'")
+		s.Greater(output.Cardinality, 0)
+	})
+}
+
+func (s *MetricsE2ESuite) TestGetAlerts() {
+	if s.alertmanagerURL == "" {
+		s.T().Skip("Alertmanager URL not available, skipping alerts test")
+	}
+
+	s.Run("retrieves alerts from Alertmanager", func() {
+		toolResult, err := s.CallTool("get_alerts", map[string]any{})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output alertsOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.NotNil(output.Alerts, "expected alerts array")
+	})
+}
+
+func (s *MetricsE2ESuite) TestGetSilences() {
+	if s.alertmanagerURL == "" {
+		s.T().Skip("Alertmanager URL not available, skipping silences test")
+	}
+
+	s.Run("retrieves silences from Alertmanager", func() {
+		toolResult, err := s.CallTool("get_silences", map[string]any{})
+		s.Require().NoError(err)
+		s.Require().False(toolResult.IsError, "tool returned error: %s", textContent(toolResult))
+
+		var output silencesOutput
+		s.Require().NoError(json.Unmarshal([]byte(textContent(toolResult)), &output))
+		s.NotNil(output.Silences, "expected silences array")
+	})
+}
+
+func TestMetricsE2E(t *testing.T) {
+	suite.Run(t, new(MetricsE2ESuite))
+}
+
+func textContent(result *mcpsdk.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	if tc, ok := result.Content[0].(*mcpsdk.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+type listMetricsOutput struct {
+	Metrics []string `json:"metrics"`
+}
+
+type instantQueryOutput struct {
+	ResultType string `json:"resultType"`
+	Result     []any  `json:"result"`
+}
+
+type rangeQueryOutput struct {
+	ResultType string `json:"resultType"`
+	Summary    []any  `json:"summary,omitempty"`
+	Result     []any  `json:"result,omitempty"`
+}
+
+type labelNamesOutput struct {
+	Labels []string `json:"labels"`
+}
+
+type labelValuesOutput struct {
+	Values []string `json:"values"`
+}
+
+type seriesOutput struct {
+	Series      []map[string]string `json:"series"`
+	Cardinality int                 `json:"cardinality"`
+}
+
+type alertsOutput struct {
+	Alerts []any `json:"alerts"`
+}
+
+type silencesOutput struct {
+	Silences []any `json:"silences"`
+}

--- a/vendor/github.com/rhobs/obs-mcp/pkg/toolset/config/config.go
+++ b/vendor/github.com/rhobs/obs-mcp/pkg/toolset/config/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/prometheus"
 )
 
+const MetricsToolSetName = "metrics"
+
 // Config holds obs-mcp toolset configuration
 type Config struct {
 	// PrometheusURL is the URL of the Prometheus/Thanos Querier endpoint.
@@ -103,5 +105,5 @@ func obsMCPToolsetParser(_ context.Context, primitive toml.Primitive, md toml.Me
 }
 
 func init() {
-	serverconfig.RegisterToolsetConfig("metrics", obsMCPToolsetParser)
+	serverconfig.RegisterToolsetConfig(MetricsToolSetName, obsMCPToolsetParser)
 }

--- a/vendor/github.com/rhobs/obs-mcp/pkg/toolset/tools/prometheus_client.go
+++ b/vendor/github.com/rhobs/obs-mcp/pkg/toolset/tools/prometheus_client.go
@@ -26,7 +26,7 @@ const (
 
 // getConfig retrieves the obs-mcp toolset configuration from params.
 func getConfig(params api.ToolHandlerParams) *toolsetconfig.Config {
-	if cfg, ok := params.GetToolsetConfig("obs-mcp"); ok {
+	if cfg, ok := params.GetToolsetConfig(toolsetconfig.MetricsToolSetName); ok {
 		if obsCfg, ok := cfg.(*toolsetconfig.Config); ok {
 			return obsCfg
 		}

--- a/vendor/github.com/rhobs/obs-mcp/pkg/toolset/toolset.go
+++ b/vendor/github.com/rhobs/obs-mcp/pkg/toolset/toolset.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 
+	"github.com/rhobs/obs-mcp/pkg/toolset/config"
 	toolset_tools "github.com/rhobs/obs-mcp/pkg/toolset/tools"
 )
 
@@ -16,7 +17,7 @@ var _ api.Toolset = (*Toolset)(nil)
 
 // GetName returns the name of the toolset.
 func (t *Toolset) GetName() string {
-	return "metrics"
+	return config.MetricsToolSetName
 }
 
 // GetDescription returns a human-readable description of the toolset.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -466,7 +466,7 @@ github.com/prometheus/prometheus/tsdb/errors
 github.com/prometheus/prometheus/tsdb/fileutil
 github.com/prometheus/prometheus/util/annotations
 github.com/prometheus/prometheus/util/strutil
-# github.com/rhobs/obs-mcp v0.1.0
+# github.com/rhobs/obs-mcp v0.1.1
 ## explicit; go 1.25.6
 github.com/rhobs/obs-mcp/pkg/alertmanager
 github.com/rhobs/obs-mcp/pkg/prometheus


### PR DESCRIPTION
```bash
─░▒▓ ~/github.com/slashpai/openshift-mcp-server  bump-obs-mcp ····················································· ✔  3s │ 3.13  Py  1.25.5 Go  16:59:13 ▓▒░─╮
╰─ make test-observability-e2e                                                                                                                                ─╯
go test -tags observability_e2e -count=1 -v ./pkg/observability/tests/
=== RUN   TestMetricsE2E
    metrics_test.go:79: Prometheus URL: https://thanos-querier-openshift-monitoring.apps.rosa.th7dp-vyyvq-ncq.jhfi.p3.openshiftapps.com
    metrics_test.go:80: Alertmanager URL: https://alertmanager-main-openshift-monitoring.apps.rosa.th7dp-vyyvq-ncq.jhfi.p3.openshiftapps.com
2026/04/24 16:59:28 INFO ListMetricsHandler called
2026/04/24 16:59:29 INFO ListMetricsHandler executed successfully resultLength=71
    metrics_test.go:88: Test metric: cluster:capacity_cpu_cores:sum
=== RUN   TestMetricsE2E/TestExecuteInstantQuery
=== RUN   TestMetricsE2E/TestExecuteInstantQuery/executes_an_instant_query
2026/04/24 16:59:30 INFO ExecuteInstantQueryHandler called
2026/04/24 16:59:31 INFO ExecuteInstantQueryHandler executed successfully resultLength=1
=== RUN   TestMetricsE2E/TestExecuteRangeQuery
=== RUN   TestMetricsE2E/TestExecuteRangeQuery/executes_a_range_query_with_step
2026/04/24 16:59:33 INFO ExecuteRangeQueryHandler called
2026/04/24 16:59:33 INFO ExecuteRangeQueryHandler executed successfully resultLength=1
=== RUN   TestMetricsE2E/TestGetAlerts
=== RUN   TestMetricsE2E/TestGetAlerts/retrieves_alerts_from_Alertmanager
2026/04/24 16:59:35 INFO GetAlertsHandler called
2026/04/24 16:59:36 INFO GetAlertsHandler executed successfully alertCount=2
=== RUN   TestMetricsE2E/TestGetLabelNames
=== RUN   TestMetricsE2E/TestGetLabelNames/retrieves_label_names_for_a_metric
2026/04/24 16:59:37 INFO GetLabelNamesHandler called
2026/04/24 16:59:37 INFO GetLabelNamesHandler executed successfully labelCount=6
=== RUN   TestMetricsE2E/TestGetLabelValues
=== RUN   TestMetricsE2E/TestGetLabelValues/retrieves_label_values_for___name___label
2026/04/24 16:59:39 INFO GetLabelValuesHandler called
2026/04/24 16:59:39 INFO GetLabelValuesHandler executed successfully valueCount=1
=== RUN   TestMetricsE2E/TestGetSeries
=== RUN   TestMetricsE2E/TestGetSeries/retrieves_series_for_a_metric
2026/04/24 16:59:41 INFO GetSeriesHandler called
2026/04/24 16:59:41 INFO GetSeriesHandler executed successfully cardinality=1
=== RUN   TestMetricsE2E/TestGetSilences
=== RUN   TestMetricsE2E/TestGetSilences/retrieves_silences_from_Alertmanager
2026/04/24 16:59:42 INFO GetSilencesHandler called
2026/04/24 16:59:43 INFO GetSilencesHandler executed successfully silenceCount=0
=== RUN   TestMetricsE2E/TestListMetrics
=== RUN   TestMetricsE2E/TestListMetrics/lists_metrics_matching_a_regex_pattern
2026/04/24 16:59:45 INFO ListMetricsHandler called
2026/04/24 16:59:45 INFO ListMetricsHandler executed successfully resultLength=71
=== RUN   TestMetricsE2E/TestShowTimeseries
=== RUN   TestMetricsE2E/TestShowTimeseries/validates_a_range_query_for_chart_rendering
2026/04/24 16:59:46 INFO ShowTimeseriesHandler called
2026/04/24 16:59:46 INFO ExecuteRangeQueryHandler called
2026/04/24 16:59:47 INFO ExecuteRangeQueryHandler executed successfully resultLength=1
--- PASS: TestMetricsE2E (20.92s)
    --- PASS: TestMetricsE2E/TestExecuteInstantQuery (2.14s)
        --- PASS: TestMetricsE2E/TestExecuteInstantQuery/executes_an_instant_query (0.71s)
    --- PASS: TestMetricsE2E/TestExecuteRangeQuery (2.41s)
        --- PASS: TestMetricsE2E/TestExecuteRangeQuery/executes_a_range_query_with_step (0.70s)
    --- PASS: TestMetricsE2E/TestGetAlerts (2.30s)
        --- PASS: TestMetricsE2E/TestGetAlerts/retrieves_alerts_from_Alertmanager (0.77s)
    --- PASS: TestMetricsE2E/TestGetLabelNames (1.67s)
        --- PASS: TestMetricsE2E/TestGetLabelNames/retrieves_label_names_for_a_metric (0.23s)
    --- PASS: TestMetricsE2E/TestGetLabelValues (1.64s)
        --- PASS: TestMetricsE2E/TestGetLabelValues/retrieves_label_values_for___name___label (0.23s)
    --- PASS: TestMetricsE2E/TestGetSeries (1.83s)
        --- PASS: TestMetricsE2E/TestGetSeries/retrieves_series_for_a_metric (0.24s)
    --- PASS: TestMetricsE2E/TestGetSilences (2.33s)
        --- PASS: TestMetricsE2E/TestGetSilences/retrieves_silences_from_Alertmanager (0.75s)
    --- PASS: TestMetricsE2E/TestListMetrics (1.71s)
        --- PASS: TestMetricsE2E/TestListMetrics/lists_metrics_matching_a_regex_pattern (0.23s)
    --- PASS: TestMetricsE2E/TestShowTimeseries (2.14s)
        --- PASS: TestMetricsE2E/TestShowTimeseries/validates_a_range_query_for_chart_rendering (0.73s)
PASS
ok  	github.com/containers/kubernetes-mcp-server/pkg/observability/tests	21.973s
╭─░▒▓ ~/github.com/slashpai/openshift-mcp-server  bump-obs-mcp ···················································· ✔  26s │ 3.13  Py  1.25.5 Go  16:59:47 ▓▒░─╮
╰─
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end testing for metrics functionality, including instant and range query validation, metric discovery, label and timeseries operations, and alert management capabilities with automated infrastructure detection.

* **Chores**
  * Updated observability toolset dependency to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->