### PR TITLE
NO-JIRA: [release-0.3] e2e: switch MCP Gateway install from kustomize to OLM + Helm

### DIFF
--- a/build/openshift/e2e.mk
+++ b/build/openshift/e2e.mk
@@ -4,8 +4,9 @@ E2E_NAMESPACE ?= openshift-mcp-server-e2e
 MCP_LIFECYCLE_OPERATOR_VERSION ?= v0.1.0
 MCP_LIFECYCLE_OPERATOR_URL ?= https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/download/$(MCP_LIFECYCLE_OPERATOR_VERSION)/install.yaml
 MCP_SERVER_IMAGE ?= quay.io/redhat-user-workloads/ocp-mcp-server-tenant/openshift-mcp-server-release-03:latest
-MCP_GATEWAY_VERSION ?= v0.6.0
-MCP_GATEWAY_INSTALL_URL ?= https://github.com/Kuadrant/mcp-gateway/config/install?ref=$(MCP_GATEWAY_VERSION)
+MCP_GATEWAY_VERSION ?= 0.6.0
+MCP_GATEWAY_NAMESPACE ?= mcp-system
+GATEWAY_NAMESPACE ?= gateway-system
 
 .PHONY: e2e-install-operator
 e2e-install-operator: ## Install the MCP Lifecycle Operator from upstream release
@@ -19,25 +20,105 @@ e2e-install-operator: ## Install the MCP Lifecycle Operator from upstream releas
 	@echo "MCP Lifecycle Operator is ready."
 
 .PHONY: e2e-install-gateway
-e2e-install-gateway: ## Install the MCP Gateway controller and broker
-	@echo "Installing MCP Gateway $(MCP_GATEWAY_VERSION)..."
-	oc apply -k $(MCP_GATEWAY_INSTALL_URL) || true
+e2e-install-gateway: ## Install the MCP Gateway controller via OLM and deploy instance via Helm
+	@echo "Installing MCP Gateway $(MCP_GATEWAY_VERSION) via OLM..."
+	oc create ns $(GATEWAY_NAMESPACE) --dry-run=client -o yaml | oc apply -f -
+	oc create ns $(MCP_GATEWAY_NAMESPACE) --dry-run=client -o yaml | oc apply -f -
+	@echo "Applying prerequisite CRDs..."
+	oc apply -f hack/e2e/gateway-prereqs.yaml
+	oc apply -f hack/e2e/gateway-olm.yaml
+	@echo "Waiting for CatalogSource to be ready..."
+	@for i in $$(seq 1 60); do \
+		STATE=$$(oc get catalogsource mcp-gateway-catalog -n openshift-marketplace \
+			-o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null); \
+		if [ "$$STATE" = "READY" ]; then echo "CatalogSource is ready."; break; fi; \
+		if [ $$i -eq 60 ]; then echo "Timed out waiting for CatalogSource."; exit 1; fi; \
+		echo "  Waiting for CatalogSource... ($$i/60) state=$$STATE"; \
+		sleep 5; \
+	done
+	@echo "Waiting for MCP Gateway CSV to succeed..."
+	@for i in $$(seq 1 60); do \
+		PHASE=$$(oc get csv -n $(MCP_GATEWAY_NAMESPACE) \
+			-l operators.coreos.com/mcp-gateway.$(MCP_GATEWAY_NAMESPACE)="" \
+			-o jsonpath='{.items[0].status.phase}' 2>/dev/null); \
+		if [ "$$PHASE" = "Succeeded" ]; then echo "CSV succeeded."; break; fi; \
+		if [ $$i -eq 60 ]; then echo "Timed out waiting for CSV. phase=$$PHASE"; exit 1; fi; \
+		echo "  Waiting for CSV... ($$i/60) phase=$$PHASE"; \
+		sleep 5; \
+	done
 	@echo "Waiting for MCP Gateway CRDs to be established..."
-	oc wait crd/mcpgatewayextensions.mcp.kuadrant.io --for=condition=Established --timeout=60s
-	oc wait crd/mcpserverregistrations.mcp.kuadrant.io --for=condition=Established --timeout=60s
-	oc apply -k $(MCP_GATEWAY_INSTALL_URL)
-	@echo "Applying Gateway and ReferenceGrants..."
+	oc wait crd/mcpgatewayextensions.mcp.kuadrant.io --for=condition=Established --timeout=120s
+	oc wait crd/mcpserverregistrations.mcp.kuadrant.io --for=condition=Established --timeout=120s
+	@echo "Installing MCP Gateway instance via Helm..."
+	@MCP_GATEWAY_HOST=mcp.apps.$$(oc get dns cluster -o jsonpath='{.spec.baseDomain}'); \
+	echo "MCP Gateway host: $$MCP_GATEWAY_HOST"; \
+	helm upgrade -i mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
+		--version $(MCP_GATEWAY_VERSION) \
+		--namespace $(MCP_GATEWAY_NAMESPACE) \
+		--skip-crds \
+		--set controller.enabled=false \
+		--set gateway.create=true \
+		--set gateway.name=mcp-gateway \
+		--set gateway.namespace=$(GATEWAY_NAMESPACE) \
+		--set gateway.publicHost="$$MCP_GATEWAY_HOST" \
+		--set gateway.internalHostPattern="*.mcp.local" \
+		--set gateway.gatewayClassName=openshift-default \
+		--set mcpGatewayExtension.create=true \
+		--set mcpGatewayExtension.gatewayRef.name=mcp-gateway \
+		--set mcpGatewayExtension.gatewayRef.namespace=$(GATEWAY_NAMESPACE) \
+		--set mcpGatewayExtension.gatewayRef.sectionName=mcp
+	@echo "Applying ReferenceGrant for e2e namespace..."
 	oc apply -f hack/e2e/gateway.yaml
-	@echo "Waiting for mcp-gateway-controller deployment to be available..."
+	@echo "Waiting for mcp-gateway-controller deployment..."
 	oc wait deployment/mcp-gateway-controller \
-		-n mcp-system \
+		-n $(MCP_GATEWAY_NAMESPACE) \
 		--for=condition=Available \
 		--timeout=180s
-	@echo "Waiting for mcp-broker-router deployment to be available..."
-	oc wait deployment/mcp-broker-router \
-		-n mcp-system \
+	@echo "Waiting for mcp-gateway broker deployment to be created..."
+	@for i in $$(seq 1 60); do \
+		oc get deployment/mcp-gateway -n $(MCP_GATEWAY_NAMESPACE) >/dev/null 2>&1 && break; \
+		if [ $$i -eq 60 ]; then echo "Broker deployment was never created."; \
+			oc get mcpgatewayextension -n $(MCP_GATEWAY_NAMESPACE) -o yaml; \
+			oc logs -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway-controller --tail=50; \
+			exit 1; fi; \
+		echo "  Waiting for broker deployment... ($$i/60)"; \
+		sleep 5; \
+	done
+	@echo "Waiting for mcp-gateway broker to become available..."
+	@oc wait deployment/mcp-gateway \
+		-n $(MCP_GATEWAY_NAMESPACE) \
 		--for=condition=Available \
-		--timeout=180s
+		--timeout=180s || { \
+		echo "mcp-gateway broker not ready. Dumping debug info..."; \
+		echo "--- Pod status ---"; \
+		oc get pods -n $(MCP_GATEWAY_NAMESPACE) -o wide; \
+		echo "--- Pod describe ---"; \
+		oc describe pods -n $(MCP_GATEWAY_NAMESPACE) -l app.kubernetes.io/name=mcp-gateway; \
+		echo "--- Pod logs ---"; \
+		oc logs -n $(MCP_GATEWAY_NAMESPACE) -l app.kubernetes.io/name=mcp-gateway --tail=100; \
+		echo "--- MCPGatewayExtension ---"; \
+		oc get mcpgatewayextension -n $(MCP_GATEWAY_NAMESPACE) -o yaml; \
+		echo "--- Events ---"; \
+		oc get events -n $(MCP_GATEWAY_NAMESPACE) --sort-by='.lastTimestamp' | tail -20; \
+		exit 1; \
+	}
+	@echo "Waiting for Gateway to be programmed..."
+	@for i in $$(seq 1 30); do \
+		STATUS=$$(oc get gateway mcp-gateway -n $(GATEWAY_NAMESPACE) \
+			-o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null); \
+		if [ "$$STATUS" = "True" ]; then echo "Gateway is programmed."; break; fi; \
+		if [ $$i -eq 30 ]; then echo "Gateway not programmed."; \
+			oc get gateway mcp-gateway -n $(GATEWAY_NAMESPACE) -o yaml; exit 1; fi; \
+		echo "  Waiting for Gateway... ($$i/30)"; \
+		sleep 5; \
+	done
+	@echo "Creating Route for MCP Gateway..."
+	@MCP_GATEWAY_HOST=mcp.apps.$$(oc get dns cluster -o jsonpath='{.spec.baseDomain}'); \
+	oc create route edge mcp-gateway \
+		--service=mcp-gateway-openshift-default \
+		--hostname="$$MCP_GATEWAY_HOST" \
+		--port=mcp \
+		-n $(GATEWAY_NAMESPACE) 2>/dev/null || true
 	@echo "MCP Gateway is ready."
 
 .PHONY: e2e-deploy-mcp-server
@@ -86,7 +167,7 @@ e2e-wait-ready: ## Wait for MCP server deployment to become ready
 		exit 1; \
 	fi
 	@echo "Creating Route for direct MCP server access..."
-	oc expose svc/kubernetes-mcp-server -n $(E2E_NAMESPACE)
+	oc expose svc/kubernetes-mcp-server -n $(E2E_NAMESPACE) || true
 	@echo "Sending direct MCP initialize request via Route..."
 	@ROUTE_HOST=$$(oc get route/kubernetes-mcp-server -n $(E2E_NAMESPACE) -o jsonpath='{.spec.host}'); \
 	if [ -z "$$ROUTE_HOST" ]; then \
@@ -111,43 +192,50 @@ e2e-wait-ready: ## Wait for MCP server deployment to become ready
 		cat /tmp/mcp-direct.json; \
 		exit 1; \
 	fi
-	@echo "Verifying MCPServerRegistration exists..."
-	oc get mcpserverregistration/kubernetes-mcp-server -n $(E2E_NAMESPACE)
-	@echo "E2E smoke test passed. MCP server is running and reachable via MCP Gateway."
+	@echo "MCP server is running and reachable."
 
 .PHONY: e2e-smoke-test
 e2e-smoke-test: ## Smoke test the MCP server through the MCP Gateway
-	@echo "Retrieving Gateway address..."
-	@GW_HOST=""; \
-	for i in $$(seq 1 30); do \
-		GW_HOST=$$(oc get gateway mcp-gateway -n gateway-system -o jsonpath='{.status.addresses[0].value}' 2>/dev/null); \
-		if [ -n "$$GW_HOST" ]; then break; fi; \
-		echo "Waiting for Gateway address... ($$i/30)"; \
+	@echo "Waiting for MCPServerRegistration to be ready (broker polls every 60s)..."
+	@for i in $$(seq 1 24); do \
+		READY=$$(oc get mcpserverregistration/kubernetes-mcp-server -n $(E2E_NAMESPACE) \
+			-o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null); \
+		if [ "$$READY" = "True" ]; then echo "MCPServerRegistration is ready."; break; fi; \
+		if [ $$i -eq 24 ]; then echo "MCPServerRegistration not ready."; \
+			oc get mcpserverregistration -n $(E2E_NAMESPACE) -o yaml; \
+			oc logs -n $(MCP_GATEWAY_NAMESPACE) deployment/mcp-gateway --tail=30; exit 1; fi; \
+		echo "  Waiting for MCPServerRegistration... ($$i/24)"; \
 		sleep 5; \
-	done; \
-	if [ -z "$$GW_HOST" ]; then \
-		echo "Gateway did not receive an address."; \
-		oc get gateway mcp-gateway -n gateway-system -o yaml; \
+	done
+	@echo "Retrieving Gateway Route host..."
+	@ROUTE_HOST=$$(oc get route/mcp-gateway -n $(GATEWAY_NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ROUTE_HOST" ]; then \
+		echo "Gateway Route has no host. Dumping debug info..."; \
+		oc get routes -n $(GATEWAY_NAMESPACE) -o wide; \
+		oc get svc -n $(GATEWAY_NAMESPACE) -o wide; \
 		exit 1; \
 	fi; \
-	echo "Gateway address: $$GW_HOST"; \
+	echo "Gateway Route host: $$ROUTE_HOST"; \
 	echo "Sending MCP initialize request through Gateway..."; \
 	HTTP_CODE=$$(curl -s -o /tmp/mcp-response.json -w '%{http_code}' --max-time 10 \
-		-X POST "http://$$GW_HOST/mcp" \
+		-X POST "https://$$ROUTE_HOST/mcp" \
 		-H "Content-Type: application/json" \
+		-k \
 		-d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-smoke-test","version":"1.0.0"}},"id":1}'); \
 	echo "HTTP status: $$HTTP_CODE"; \
 	cat /tmp/mcp-response.json 2>/dev/null; echo; \
 	if [ "$$HTTP_CODE" != "200" ]; then \
 		echo "Expected HTTP 200, got $$HTTP_CODE. Dumping debug info..."; \
 		echo "--- Gateway status ---"; \
-		oc get gateway mcp-gateway -n gateway-system -o yaml; \
+		oc get gateway mcp-gateway -n $(GATEWAY_NAMESPACE) -o yaml; \
 		echo "--- HTTPRoute status ---"; \
 		oc get httproute kubernetes-mcp-server -n $(E2E_NAMESPACE) -o yaml; \
 		echo "--- MCPServerRegistration ---"; \
 		oc get mcpserverregistration kubernetes-mcp-server -n $(E2E_NAMESPACE) -o yaml; \
+		echo "--- MCPGatewayExtension ---"; \
+		oc get mcpgatewayextension -n $(MCP_GATEWAY_NAMESPACE) -o yaml; \
 		echo "--- Broker logs ---"; \
-		oc logs -n mcp-system -l app=mcp-broker-router --tail=50; \
+		oc logs -n $(MCP_GATEWAY_NAMESPACE) -l app.kubernetes.io/name=mcp-gateway --tail=50; \
 		exit 1; \
 	fi; \
 	if ! grep -q '"result"' /tmp/mcp-response.json; then \

--- a/hack/e2e/gateway-olm.yaml
+++ b/hack/e2e/gateway-olm.yaml
@@ -1,0 +1,30 @@
+# OLM components for installing the MCP Gateway controller on OpenShift
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: mcp-gateway-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: ghcr.io/kuadrant/mcp-controller-catalog:v0.6.0
+  displayName: MCP Gateway
+  grpcPodConfig:
+    securityContextConfig: restricted
+  publisher: Kuadrant
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: mcp-gateway
+  namespace: mcp-system
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mcp-gateway
+  namespace: mcp-system
+spec:
+  source: mcp-gateway-catalog
+  sourceNamespace: openshift-marketplace
+  name: mcp-gateway
+  channel: preview

--- a/hack/e2e/gateway-prereqs.yaml
+++ b/hack/e2e/gateway-prereqs.yaml
@@ -1,0 +1,32 @@
+# GatewayClass for OpenShift - required for the Gateway API to work.
+# On OCP 4.17+, this may already exist; applying is idempotent.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: openshift.io/gateway-controller/v1
+---
+# EnvoyFilter CRD stub - the MCP Gateway controller watches this Istio CRD.
+# On clusters without Service Mesh, we install a minimal CRD so the controller
+# cache can sync without crashing.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: envoyfilters.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    kind: EnvoyFilter
+    listKind: EnvoyFilterList
+    plural: envoyfilters
+    singular: envoyfilter
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/hack/e2e/gateway.yaml
+++ b/hack/e2e/gateway.yaml
@@ -1,39 +1,6 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: gateway-system
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: mcp-gateway
-  namespace: gateway-system
-spec:
-  gatewayClassName: openshift-default
-  listeners:
-  - name: mcp
-    protocol: HTTP
-    port: 8080
-    allowedRoutes:
-      namespaces:
-        from: All
----
-# Allow MCPGatewayExtension in mcp-system to reference Gateway in gateway-system
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: ReferenceGrant
-metadata:
-  name: allow-mcp-gateway-extension
-  namespace: gateway-system
-spec:
-  from:
-  - group: mcp.kuadrant.io
-    kind: MCPGatewayExtension
-    namespace: mcp-system
-  to:
-  - group: gateway.networking.k8s.io
-    kind: Gateway
----
-# Allow HTTPRoutes in e2e namespace to reference Gateway in gateway-system
+# Allow HTTPRoutes in e2e namespace to reference Gateway in gateway-system.
+# The Gateway, MCPGatewayExtension, and their ReferenceGrant are created by the
+# mcp-gateway Helm chart during e2e-install-gateway.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:

--- a/hack/e2e/mcpserver-registration.yaml
+++ b/hack/e2e/mcpserver-registration.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kubernetes-mcp-server
   namespace: openshift-mcp-server-e2e
 spec:
+  hostnames:
+  - kubernetes-mcp-server.mcp.local
   parentRefs:
   - name: mcp-gateway
     namespace: gateway-system


### PR DESCRIPTION
Replace the raw kustomize-based install of the MCP Gateway controller with the official OpenShift install path: OLM for the controller and the mcp-gateway Helm OCI chart for the Gateway instance resources.

This resolves several issues with the kustomize approach:
- Missing RBAC for apps/deployments at cluster scope
- Missing Istio EnvoyFilter CRD on non-Service-Mesh clusters
- MCPGatewayExtension requiring publicHost or listener hostname

The OLM install uses the official CatalogSource from ghcr.io and the Helm chart creates the Gateway, MCPGatewayExtension, and ReferenceGrant with the correct publicHost derived from the cluster's base domain.

The smoke test now creates an edge-terminated Route for the Gateway service and validates the full request path: client -> Route -> Gateway -> broker-router -> backend MCP server.