### PR TITLE
GIE-507: update observability task prompts to request metric names and PromQL queries

### DIFF
--- a/evals/tasks/observability/labels/series-by-namespace.yaml
+++ b/evals/tasks/observability/labels/series-by-namespace.yaml
@@ -25,4 +25,5 @@ spec:
   prompt:
     inline: |
       How many time series exist for container_cpu_usage_seconds_total
-      in the openshift-monitoring namespace?
+      in the openshift-monitoring namespace? List the label dimensions
+      (such as pod, container) present in the series.

--- a/evals/tasks/observability/queries/cpu-usage.yaml
+++ b/evals/tasks/observability/queries/cpu-usage.yaml
@@ -22,4 +22,5 @@ spec:
         reason: "Verify the response identifies specific pods"
   prompt:
     inline: |
-      Which pods are using the most CPU?
+      Which pods are using the most CPU? Show me the top 5.
+      Use Prometheus metrics and include the metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/crashlooping-pods.yaml
+++ b/evals/tasks/observability/queries/crashlooping-pods.yaml
@@ -20,3 +20,4 @@ spec:
   prompt:
     inline: |
       Which pods were crashlooping in the last 5 minutes?
+      Use Prometheus metrics and include the metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/diagnose-cluster-health.yaml
+++ b/evals/tasks/observability/queries/diagnose-cluster-health.yaml
@@ -25,4 +25,5 @@ spec:
   prompt:
     inline: |
       Is the cluster healthy? Give me an overview of any issues.
-      Check alerts, node status, and pod health.
+      Check alerts, node status, and pod health using Prometheus metrics.
+      Include the metric names and PromQL queries you used.

--- a/evals/tasks/observability/queries/memory-usage.yaml
+++ b/evals/tasks/observability/queries/memory-usage.yaml
@@ -23,3 +23,4 @@ spec:
   prompt:
     inline: |
       Which pods are using the most memory? Show me the top 5.
+      Use Prometheus metrics and include the metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/namespace-pod-count.yaml
+++ b/evals/tasks/observability/queries/namespace-pod-count.yaml
@@ -25,3 +25,4 @@ spec:
   prompt:
     inline: |
       Which namespaces have the most running pods? Show me the top 5.
+      Use Prometheus metrics and include the metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/namespace-resource-usage.yaml
+++ b/evals/tasks/observability/queries/namespace-resource-usage.yaml
@@ -26,3 +26,4 @@ spec:
     inline: |
       Which namespace is consuming the most CPU and memory?
       Show me the top namespace for each.
+      Use Prometheus metrics and include the metric names and PromQL queries you used.

--- a/evals/tasks/observability/queries/network-traffic.yaml
+++ b/evals/tasks/observability/queries/network-traffic.yaml
@@ -23,3 +23,4 @@ spec:
   prompt:
     inline: |
       Which pods are receiving the most network traffic?
+      Use Prometheus metrics and include the metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/pending-pods.yaml
+++ b/evals/tasks/observability/queries/pending-pods.yaml
@@ -21,3 +21,4 @@ spec:
   prompt:
     inline: |
       Which pods are stuck in pending state?
+      Use Prometheus metrics and include the metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/pods-created.yaml
+++ b/evals/tasks/observability/queries/pods-created.yaml
@@ -20,3 +20,4 @@ spec:
   prompt:
     inline: |
       How many pods were created in the last 5 minutes?
+      Include the Prometheus metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/prometheus-head-series.yaml
+++ b/evals/tasks/observability/queries/prometheus-head-series.yaml
@@ -20,3 +20,4 @@ spec:
   prompt:
     inline: |
       How many head series does Prometheus have?
+      Include the Prometheus metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/prometheus-requests.yaml
+++ b/evals/tasks/observability/queries/prometheus-requests.yaml
@@ -20,3 +20,4 @@ spec:
   prompt:
     inline: |
       How many requests per second are being made to Prometheus?
+      Include the Prometheus metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/prometheus-wal-size.yaml
+++ b/evals/tasks/observability/queries/prometheus-wal-size.yaml
@@ -20,3 +20,4 @@ spec:
   prompt:
     inline: |
       What is the current storage size of the Prometheus WAL?
+      Include the Prometheus metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/time-range-query.yaml
+++ b/evals/tasks/observability/queries/time-range-query.yaml
@@ -24,3 +24,4 @@ spec:
   prompt:
     inline: |
       Show me the CPU usage trend for pods in the default namespace over the last 30 minutes.
+      Include the Prometheus metric name and PromQL query you used.

--- a/evals/tasks/observability/queries/visualize-cpu-usage.yaml
+++ b/evals/tasks/observability/queries/visualize-cpu-usage.yaml
@@ -21,3 +21,4 @@ spec:
   prompt:
     inline: |
       Visualize the CPU usage for pods in the default namespace over the last 30 minutes.
+      Include the Prometheus metric name and PromQL query you used.


### PR DESCRIPTION
After running the evals with gpt 5.5 (60 %) I saw evals pass percenatage lowered than gpt-5-nano (64%)

A few observability eval tasks were failing even when the agent got the correct answer. The agent gets the right answer but summarizes in natural language without restating the metric name. 

So updated prompts to explicitly ask the agent to report the PromQL query/metric name used to force the metric name into the response


I ran with gpt-5-nano and got these results after updating evals

```bash
make run-evals EVAL_LABEL_SELECTOR=suite=observability
```

```bash
cat mcpchecker-openai-agent-kubernetes-test-out.json | jq '{                                                                                       ─╯
  total: length,
  passed: [.[] | select(.taskPassed == true)] | length,
  failed: [.[] | select(.taskPassed == false)] | length,
  pass_rate: (([.[] | select(.taskPassed == true)] | length) * 100.0 / length | round),
  failed_tasks: [.[] | select(.taskPassed == false) | .taskName]
}'
{
  "total": 28,
  "passed": 25,
  "failed": 3,
  "pass_rate": 89,
  "failed_tasks": [
    "memory-usage",
    "pods-created",
    "namespace-pod-count"
  ]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated observability evaluation tasks to require explicit reporting of Prometheus metrics and PromQL queries. This enhances evaluation transparency and ensures AI responses demonstrate methodology alongside results for cluster monitoring queries (CPU usage, memory usage, network traffic, pod counts, and health diagnostics).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->