### PR TITLE
GIE-509: chore(deps): bump rhobs/obs-mcp to v0.1.3

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -152,6 +152,11 @@ The toolset is configured via a `[metrics]` section in the TOML config file.
 
 ```toml
 [toolset_configs.metrics]
+# Where to read the bearer token from: "header" (default) or "kubeconfig".
+# Set to "kubeconfig" when running locally (STDIO mode) so the token is read
+# from your kubeconfig session (e.g. after `oc login`).
+auth_mode = "kubeconfig"
+
 # URL of the Prometheus or Thanos Querier endpoint.
 # Required for metric/query tools. Defaults to http://localhost:9090 if unset.
 # Example for OpenShift in-cluster Thanos:
@@ -204,6 +209,7 @@ range_query_full_response = false
 
 | Option | Type | Default | Description |
 |---|---|---|---|
+| `auth_mode` | string | `"header"` | Token source: `"header"` (from request Authorization header) or `"kubeconfig"` (from kubeconfig/REST config) |
 | `prometheus_url` | string | `http://localhost:9090` | Prometheus or Thanos Querier endpoint URL |
 | `alertmanager_url` | string | — | Alertmanager endpoint URL (required for alert/silence tools) |
 | `insecure` | bool | `false` | Skip TLS certificate verification |
@@ -216,11 +222,10 @@ range_query_full_response = false
 
 ## Authentication and TLS
 
-The toolset reuses the bearer token from the active Kubernetes/OpenShift kubeconfig (or the
-in-cluster service account token when running inside a pod). No separate credentials are needed.
+The toolset authenticates using a bearer token. The `auth_mode` option controls where it comes from:
 
-Currently there's a limitation here, as kubeconfig using client certificates, will get a 401 from Thanos Querier. 
-So users need to `oc login` first to get a token-based session.
+- `"header"` (default) — from the incoming request's Authorization header. Use when running remotely behind an OAuth proxy.
+- `"kubeconfig"` — from the kubeconfig / in-cluster REST config. Use when running **locally** (STDIO mode, e.g. via `npx` or the binary). Requires a token-based session (e.g. `oc login`) — client-certificate kubeconfigs will get a 401 from Thanos Querier.
 
 **TLS certificate resolution order:**
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/miekg/dns v1.1.68
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/rhobs/obs-mcp v0.1.1
+	github.com/rhobs/obs-mcp v0.1.3
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
-github.com/rhobs/obs-mcp v0.1.1 h1:A3Xa9ElwZN2qaf2OSShResgNs0h0ApCPVNctV/z4EQg=
-github.com/rhobs/obs-mcp v0.1.1/go.mod h1:Zuq0El4CL3JEcFCRyKqODua0Fi3LYojljTqQkGGdfJ8=
+github.com/rhobs/obs-mcp v0.1.3 h1:0m3O6SzhyKAGyolyc/5scwWCGtgslxxkjBzq1vdh588=
+github.com/rhobs/obs-mcp v0.1.3/go.mod h1:bAB3adiWDIRezreWHCcKycP9K/6baz+GVPIFIz+MqvQ=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/vendor/github.com/rhobs/obs-mcp/pkg/toolset/config/config.go
+++ b/vendor/github.com/rhobs/obs-mcp/pkg/toolset/config/config.go
@@ -13,8 +13,26 @@ import (
 
 const MetricsToolSetName = "metrics"
 
+// AuthMode defines where the bearer token is obtained for authenticating
+// against Prometheus and Alertmanager endpoints.
+type AuthMode string
+
+const (
+	// AuthModeHeader reads the bearer token from the request context (authorization header).
+	// This is the default.
+	AuthModeHeader AuthMode = "header"
+
+	// AuthModeKubeConfig reads the bearer token from the kubeconfig/REST config only.
+	AuthModeKubeConfig AuthMode = "kubeconfig"
+)
+
 // Config holds obs-mcp toolset configuration
 type Config struct {
+	// AuthMode controls where the bearer token is obtained for authenticating
+	// against Prometheus and Alertmanager endpoints.
+	// Valid values: "header" (default) - read from the request context authorization header,
+	//              "kubeconfig" - read from the kubeconfig/REST config.
+	AuthMode AuthMode `toml:"auth_mode,omitempty"`
 	// PrometheusURL is the URL of the Prometheus/Thanos Querier endpoint.
 	// This field is required. Example: "https://thanos-querier-openshift-monitoring.apps.example.com"
 	PrometheusURL string `toml:"prometheus_url,omitempty"`
@@ -55,7 +73,10 @@ var _ api.ExtendedConfig = (*Config)(nil)
 
 // Validate checks that the configuration values are valid.
 func (c *Config) Validate() error {
-	// Validate guardrails configuration
+	if c.AuthMode != "" && c.AuthMode != AuthModeHeader && c.AuthMode != AuthModeKubeConfig {
+		return fmt.Errorf("invalid auth_mode: %q (valid options: %q, %q)", c.AuthMode, AuthModeHeader, AuthModeKubeConfig)
+	}
+
 	if c.Guardrails != "" {
 		_, err := prometheus.ParseGuardrails(c.Guardrails)
 		if err != nil {
@@ -64,6 +85,14 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// GetAuthMode returns the configured token source, defaulting to TokenSourceHeader.
+func (c *Config) GetAuthMode() AuthMode {
+	if c.AuthMode == "" {
+		return AuthModeHeader
+	}
+	return c.AuthMode
 }
 
 // GetGuardrails returns the parsed guardrails configuration with cardinality limits applied.

--- a/vendor/github.com/rhobs/obs-mcp/pkg/toolset/tools/prometheus_client.go
+++ b/vendor/github.com/rhobs/obs-mcp/pkg/toolset/tools/prometheus_client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	promapi "github.com/prometheus/client_golang/api"
 	promcfg "github.com/prometheus/common/config"
 	"k8s.io/client-go/rest"
@@ -52,7 +53,7 @@ func getPromClient(params api.ToolHandlerParams) (prometheus.Loader, error) {
 		slog.Warn("Failed to parse guardrails configuration", "err", err)
 	}
 
-	apiConfig, err := createAPIConfigFromRESTConfig(params, metricsBackendURL, cfg.Insecure)
+	apiConfig, err := buildAPIConfig(params, metricsBackendURL, cfg.Insecure, cfg.GetAuthMode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API config: %w", err)
 	}
@@ -67,18 +68,32 @@ func getPromClient(params api.ToolHandlerParams) (prometheus.Loader, error) {
 	return promClient, nil
 }
 
-// createAPIConfigFromRESTConfig creates a Prometheus API config from Kubernetes REST config.
-// It builds a fresh HTTP transport without the AccessControlRoundTripper to avoid
-// Kubernetes API validation on Prometheus endpoints.
-func createAPIConfigFromRESTConfig(params api.ToolHandlerParams, prometheusURL string, insecure bool) (promapi.Config, error) {
+func resolveToken(params api.ToolHandlerParams, restConfig *rest.Config, authMode toolsetconfig.AuthMode) (string, error) {
+	slog.Info("Obtaining authentication token", "authMode", authMode)
+	switch authMode { //nolint:exhaustive // the default auth_mode value is header
+	case toolsetconfig.AuthModeKubeConfig:
+		return extractBearerToken(restConfig), nil
+	default:
+		token := readTokenFromCtx(params)
+		if token == "" {
+			return "", fmt.Errorf("no bearer token found in request context authorization header")
+		}
+		return token, nil
+	}
+}
+
+// buildAPIConfig creates a Prometheus API config using the configured auth mode.
+func buildAPIConfig(params api.ToolHandlerParams, prometheusURL string, insecure bool, authMode toolsetconfig.AuthMode) (promapi.Config, error) {
 	restConfig := params.RESTConfig()
 	if restConfig == nil {
 		return promapi.Config{}, fmt.Errorf("no REST config available")
 	}
 
-	token := extractBearerToken(restConfig)
+	token, err := resolveToken(params, restConfig, authMode)
+	if err != nil {
+		return promapi.Config{}, err
+	}
 
-	// Use the same pattern as createAPIConfigWithToken from obs-mcp/pkg/mcp/auth.go
 	return createAPIConfigWithToken(restConfig, prometheusURL, token, insecure)
 }
 
@@ -190,6 +205,18 @@ func extractBearerToken(restConfig *rest.Config) string {
 	return ""
 }
 
+func readTokenFromCtx(params api.ToolHandlerParams) string {
+	authHeader, ok := params.Value(kubernetes.OAuthAuthorizationHeader).(string)
+	if !ok {
+		return ""
+	}
+	parts := strings.Fields(authHeader)
+	if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+		return parts[1]
+	}
+	return strings.TrimSpace(authHeader)
+}
+
 // getAlertmanagerClient creates an Alertmanager client using the toolset configuration.
 func getAlertmanagerClient(params api.ToolHandlerParams) (alertmanager.Loader, error) {
 	cfg := getConfig(params)
@@ -204,8 +231,10 @@ func getAlertmanagerClient(params api.ToolHandlerParams) (alertmanager.Loader, e
 		return nil, fmt.Errorf("no REST config available")
 	}
 
-	// Extract bearer token from REST config
-	token := extractBearerToken(restConfig)
+	token, err := resolveToken(params, restConfig, cfg.GetAuthMode())
+	if err != nil {
+		return nil, err
+	}
 
 	apiConfig, err := createAPIConfigWithToken(restConfig, alertmanagerURL, token, cfg.Insecure)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -466,7 +466,7 @@ github.com/prometheus/prometheus/tsdb/errors
 github.com/prometheus/prometheus/tsdb/fileutil
 github.com/prometheus/prometheus/util/annotations
 github.com/prometheus/prometheus/util/strutil
-# github.com/rhobs/obs-mcp v0.1.1
+# github.com/rhobs/obs-mcp v0.1.3
 ## explicit; go 1.25.6
 github.com/rhobs/obs-mcp/pkg/alertmanager
 github.com/rhobs/obs-mcp/pkg/prometheus


### PR DESCRIPTION
Adds AuthMode support for configuring bearer token source (header vs kubeconfig) for Prometheus and Alertmanager endpoints.

@iNecas @tremes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable authentication mode for API clients (header or kubeconfig), with a default and normalization.
  * Documentation updated with examples and guidance for auth_mode.

* **Bug Fixes**
  * Client token resolution now follows the configured auth mode and surfaces token errors instead of silently using an empty token.

* **Chores**
  * Updated core dependency to v0.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->