### PR TITLE
NO-JIRA: [release-0.3] fix(http): fall back to openid-configuration when well-known endpoint returns empty body (#1117)

### DIFF
--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -210,7 +210,7 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 }
 
 // fetchWellKnownEndpoint creates a new request from the incoming request's method and context,
-// then fetches the well-known endpoint. Returns nil metadata if the endpoint returns 404.
+// then fetches the well-known endpoint. Returns nil metadata if the endpoint returns 404 or an empty body (to allow fallback).
 func (w *WellKnown) fetchWellKnownEndpoint(request *http.Request, url string) (map[string]interface{}, http.Header, error) {
 	req, err := http.NewRequestWithContext(request.Context(), request.Method, url, nil)
 	if err != nil {
@@ -220,7 +220,7 @@ func (w *WellKnown) fetchWellKnownEndpoint(request *http.Request, url string) (m
 }
 
 // fetchWellKnownEndpointFromRequest performs the HTTP fetch using a pre-built request.
-// Returns nil metadata if the endpoint returns 404 (to allow fallback).
+// Returns nil metadata if the endpoint returns 404 or an empty body (to allow fallback).
 func (w *WellKnown) fetchWellKnownEndpointFromRequest(req *http.Request) (map[string]interface{}, http.Header, error) {
 	resp, err := w.wellKnownHTTPClient().Do(req)
 	if err != nil {
@@ -239,6 +239,11 @@ func (w *WellKnown) fetchWellKnownEndpointFromRequest(req *http.Request) (map[st
 
 	var resourceMetadata map[string]interface{}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxWellKnownResponseSize)).Decode(&resourceMetadata); err != nil {
+		// Treat empty body (io.EOF) as equivalent to 404 — some providers (e.g., Entra ID)
+		// return HTTP 200 with content-length: 0 for unsupported well-known paths.
+		if err == io.EOF {
+			return nil, nil, nil
+		}
 		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 

--- a/pkg/http/wellknown_test.go
+++ b/pkg/http/wellknown_test.go
@@ -398,6 +398,53 @@ func (s *WellknownSuite) TestMetadataGenerationFallback() {
 		s.Contains(string(body), `"scopes_supported":`, "Expected scopes_supported from openid-configuration")
 	})
 
+	s.Run("falls back to openid-configuration when upstream returns 200 with empty body", func() {
+		// Entra ID returns HTTP 200 with content-length: 0 for unsupported well-known paths
+		s.TestServer.Close()
+		s.TestServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.EscapedPath() {
+			case "/.well-known/openid-configuration":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"issuer": "https://login.microsoftonline.com/tenant/v2.0",
+					"authorization_endpoint": "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize",
+					"token_endpoint": "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+					"scopes_supported": ["openid", "profile", "email"]
+				}`))
+			default:
+				w.Header().Set("Content-Length", "0")
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		s.StaticConfig.AuthorizationURL = s.TestServer.URL
+		s.StaticConfig.RequireOAuth = true
+		s.StartServer()
+
+		s.Run("oauth-authorization-server", func() {
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/.well-known/oauth-authorization-server", s.StaticConfig.Port))
+			s.Require().NoError(err)
+			s.T().Cleanup(func() { _ = resp.Body.Close() })
+
+			s.Equal(http.StatusOK, resp.StatusCode, "Expected fallback to succeed")
+
+			body, err := io.ReadAll(resp.Body)
+			s.Require().NoError(err)
+			s.Contains(string(body), "login.microsoftonline.com", "Expected Entra ID issuer in response")
+		})
+
+		s.Run("oauth-protected-resource", func() {
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/.well-known/oauth-protected-resource", s.StaticConfig.Port))
+			s.Require().NoError(err)
+			s.T().Cleanup(func() { _ = resp.Body.Close() })
+
+			s.Equal(http.StatusOK, resp.StatusCode, "Expected fallback to succeed")
+
+			body, err := io.ReadAll(resp.Body)
+			s.Require().NoError(err)
+			s.Contains(string(body), `"authorization_servers":`, "Expected authorization_servers in response")
+		})
+	})
+
 	s.Run("returns 404 when both oauth-authorization-server and openid-configuration return 404", func() {
 		s.TestServer.Close()
 		s.TestServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
cherry pick of https://github.com/containers/kubernetes-mcp-server/pull/1117 upstream 