### PR TITLE
NO-JIRA: [release-0.3] test: add Go-based e2e smoke test for MCP Gateway integration

### DIFF
--- a/build/openshift/e2e.mk
+++ b/build/openshift/e2e.mk
@@ -245,8 +245,17 @@ e2e-smoke-test: ## Smoke test the MCP server through the MCP Gateway
 	fi; \
 	echo "Smoke test passed. MCP server responded through the MCP Gateway."
 
+.PHONY: e2e-go-smoke-test
+e2e-go-smoke-test: ## Run Go-based e2e smoke tests against the MCP Gateway
+	@echo "Running Go e2e smoke tests..."
+	@ROUTE_HOST=$$(oc get route/mcp-gateway -n $(GATEWAY_NAMESPACE) \
+		-o jsonpath='{.spec.host}'); \
+	echo "Gateway endpoint: https://$$ROUTE_HOST/mcp"; \
+	MCP_GATEWAY_ENDPOINT="https://$$ROUTE_HOST/mcp" \
+	go test -tags e2e -v -count=1 ./e2e/...
+
 .PHONY: e2e-setup
 e2e-setup: e2e-install-operator e2e-install-gateway e2e-deploy-mcp-server e2e-register-mcp-server e2e-wait-ready ## Install all components and wait for readiness
 
 .PHONY: e2e-test
-e2e-test: e2e-setup e2e-smoke-test ## Run the full e2e test (setup + smoke tests)
+e2e-test: e2e-setup e2e-smoke-test e2e-go-smoke-test ## Run the full e2e test (setup + smoke tests)

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -1,0 +1,65 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/stretchr/testify/suite"
+)
+
+type GatewaySuite struct {
+	suite.Suite
+	*test.McpClient
+	endpoint string
+}
+
+func (s *GatewaySuite) SetupSuite() {
+	endpoint := os.Getenv("MCP_GATEWAY_ENDPOINT")
+	if endpoint == "" {
+		s.T().Skip("MCP_GATEWAY_ENDPOINT not set, skipping e2e tests")
+	}
+	s.endpoint = endpoint
+}
+
+func (s *GatewaySuite) SetupTest() {
+	s.McpClient = test.NewMcpClient(s.T(), nil,
+		test.WithEndpoint(s.endpoint),
+		test.WithTransport(&http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // e2e test with self-signed certs
+		}),
+		test.WithClientInfo("e2e-gateway-test", "1.0.0"),
+	)
+}
+
+func (s *GatewaySuite) TearDownTest() {
+	if s.McpClient != nil {
+		s.McpClient.Close()
+	}
+}
+
+func (s *GatewaySuite) TestInitialize() {
+	s.NotNil(s.InitializeResult, "MCP initialize should succeed")
+	s.NotEmpty(s.InitializeResult.ServerInfo.Name, "server info should have a name")
+}
+
+func (s *GatewaySuite) TestToolsHaveKubePrefix() {
+	result, err := s.ListTools()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Require().NotEmpty(result.Tools, "gateway should expose at least one tool")
+
+	for _, tool := range result.Tools {
+		s.True(strings.HasPrefix(tool.Name, "kube_"),
+			"tool %q should have kube_ prefix", tool.Name)
+	}
+}
+
+func TestGateway(t *testing.T) {
+	suite.Run(t, new(GatewaySuite))
+}

--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -24,6 +24,7 @@ type mcpClientConfig struct {
 	headers              map[string]string
 	clientInfo           *mcp.Implementation
 	endpoint             string
+	transport            http.RoundTripper
 	allowConnectionError bool
 	elicitationHandler   func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)
 	capabilities         *mcp.ClientCapabilities
@@ -81,6 +82,21 @@ func (o endpointOption) apply(c *mcpClientConfig) {
 // The URL should include the full path (e.g., "http://localhost:8080/mcp").
 func WithEndpoint(endpoint string) McpClientOption {
 	return endpointOption{endpoint: endpoint}
+}
+
+// transportOption sets a custom HTTP transport
+type transportOption struct {
+	transport http.RoundTripper
+}
+
+func (o transportOption) apply(c *mcpClientConfig) {
+	c.transport = o.transport
+}
+
+// WithTransport sets a custom HTTP transport for the MCP client.
+// This is composed with header injection when WithHTTPHeaders is also used.
+func WithTransport(transport http.RoundTripper) McpClientOption {
+	return transportOption{transport: transport}
 }
 
 // allowConnectionErrorOption allows connection errors without failing the test
@@ -204,12 +220,18 @@ func NewMcpClient(t *testing.T, mcpHttpServer http.Handler, options ...McpClient
 		endpoint = ret.testServer.URL + "/mcp"
 	}
 
-	// Create HTTP client with custom headers if provided
-	httpClient := http.DefaultClient
+	// Build base transport, using custom transport if provided
+	baseTransport := http.DefaultTransport
+	if cfg.transport != nil {
+		baseTransport = cfg.transport
+	}
+
+	// Create HTTP client with optional header injection
+	httpClient := &http.Client{Transport: baseTransport}
 	if len(cfg.headers) > 0 {
 		httpClient = &http.Client{
 			Transport: &headerRoundTripper{
-				base:    http.DefaultTransport,
+				base:    baseTransport,
 				headers: cfg.headers,
 			},
 		}


### PR DESCRIPTION
Add a proper Go test that connects to the MCP Gateway endpoint, performs the full MCP protocol handshake, lists tools, and asserts that tools are returned with the expected kube_ prefix. This
validates the complete integration chain: Gateway -> broker ->
MCP server -> tool discovery -> prefix rewriting.

- Add WithInsecureTLS() option to internal/test McpClient for self-signed certificates
- Create e2e/gateway_test.go with testify/suite (consistent with the rest of the repo), gated behind //go:build e2e
- Add e2e-go-smoke-test Makefile target, wired into e2e-test chain