### PR TITLE
NO-JIRA: Fix namespace mismatch for multi-cluster Konflux repository configuration

### DIFF
--- a/.tekton/openshift-mcp-server-pull-request.yaml
+++ b/.tekton/openshift-mcp-server-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/target-namespace: "crt-nshift-lightspeed-tenant"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: ols

--- a/.tekton/openshift-mcp-server-push.yaml
+++ b/.tekton/openshift-mcp-server-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/target-namespace: "crt-nshift-lightspeed-tenant"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: ols


### PR DESCRIPTION
## Summary

This PR fixes namespace mismatch failures when the same Git repository is configured in multiple Konflux clusters.

## Problem

The same repository can be added to multiple Konflux clusters, and this configuration itself is supported.

However, when both clusters receive the same Git webhook events, Pipelines as Code (PaC) from both clusters attempt to process the same `.tekton/` PipelineRun definitions.

This causes one of the clusters to fail with namespace validation errors similar to:

```text id="j20yn0"
the namespace of the provided object does not match the namespace sent on the request
```

because the PipelineRun definitions are being executed in clusters/namespaces they were not intended for.

## Root Cause

Both Konflux clusters were matching the same repository events and triggering PipelineRuns from the shared `.tekton/` directory without explicit namespace targeting.

As a result:

* one cluster processed the PipelineRun successfully
* the second cluster attempted to run the same PipelineRun in a mismatched namespace and failed

## Fix

This PR adds the following annotation to the PipelineRun definitions:

```yaml id="qk39a8"
pipelinesascode.tekton.dev/target-namespace
```

This ensures Pipelines as Code only triggers the PipelineRun for the intended namespace/cluster.

Example:

```yaml id="eymx3t"
metadata:
  annotations:
    pipelinesascode.tekton.dev/target-namespace: "<namespace>"
```

## Notes
Testing this if works or not
cc @matzew 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration settings to specify target deployment namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->