### PR TITLE
NO-JIRA: Fix namespace mismatch for multi-cluster Konflux repository configuration

### DIFF
--- a/.tekton/openshift-mcp-server-release-03-pull-request.yaml
+++ b/.tekton/openshift-mcp-server-release-03-pull-request.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "release-0.3"
+    pipelinesascode.tekton.dev/target-namespace: "ocp-mcp-server-tenant"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: mcp-server-03

--- a/.tekton/openshift-mcp-server-release-03-push.yaml
+++ b/.tekton/openshift-mcp-server-release-03-push.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "release-0.3"
+    pipelinesascode.tekton.dev/target-namespace: "ocp-mcp-server-tenant"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: mcp-server-03


### PR DESCRIPTION
## Summary

This PR fixes namespace mismatch failures when the same Git repository is configured in multiple Konflux clusters.

## Problem

The same repository can be added to multiple Konflux clusters, and this configuration itself is supported.

However, when both clusters receive the same Git webhook events, Pipelines as Code (PaC) from both clusters attempt to process the same `.tekton/` PipelineRun definitions.

This causes one of the clusters to fail with namespace validation errors similar to:

```text id="j20yn0"
the namespace of the provided object does not match the namespace sent on the request
```

because the PipelineRun definitions are being executed in clusters/namespaces they were not intended for.

## Root Cause

Both Konflux clusters were matching the same repository events and triggering PipelineRuns from the shared `.tekton/` directory without explicit namespace targeting.

As a result:

* one cluster processed the PipelineRun successfully
* the second cluster attempted to run the same PipelineRun in a mismatched namespace and failed

## Fix

This PR adds the following annotation to the PipelineRun definitions:

```yaml id="qk39a8"
pipelinesascode.tekton.dev/target-namespace
```

This ensures Pipelines as Code only triggers the PipelineRun for the intended namespace/cluster.

Example:

```yaml id="eymx3t"
metadata:
  annotations:
    pipelinesascode.tekton.dev/target-namespace: "<namespace>"
```

