### PR TITLE
NO-JIRA: OCP/CI entrypoint config file setting

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -23,7 +23,6 @@ COPY --from=builder /workspace/LICENSE /licenses/.
 USER 65532:65532
 
 COPY mcp_config.toml /mcp_config.toml
-ENV CONFIG_PATH=/mcp_config.toml
 
 # Labels for enterprise contract
 LABEL com.redhat.component=openshift-mcp-server
@@ -38,4 +37,4 @@ LABEL vendor="Red Hat, Inc."
 LABEL version=0.0.1
 LABEL summary="Red Hat OpenShift MCP Server"
 
-ENTRYPOINT ["/openshift-mcp-server", "--config", "$CONFIG_PATH"]
+ENTRYPOINT ["/openshift-mcp-server", "--config", "/mcp_config.toml"]

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -23,7 +23,6 @@ COPY --from=builder /workspace/LICENSE /licenses/.
 USER 65532:65532
 
 COPY mcp_config.toml /mcp_config.toml
-ENV CONFIG_PATH=/mcp_config.toml
 
 # Labels for enterprise contract
 LABEL com.redhat.component=openshift-mcp-server
@@ -40,4 +39,4 @@ LABEL version=0.0.1
 LABEL summary="Red Hat OpenShift MCP Server"
 LABEL konflux.additional-tags="latest"
 
-ENTRYPOINT ["/openshift-mcp-server", "--config", "$CONFIG_PATH"]
+ENTRYPOINT ["/openshift-mcp-server", "--config", "/mcp_config.toml"]


### PR DESCRIPTION
The entrypoints in Dockerfile.ocp and .ci were trying to use a `$CONFIG_PATH` env var on the CLI to reference the config file; but that was coming through as a string and not being interpolated by the shell.
Two ways to fix:
- Run the entrypoint through a shell to get that var expanded
- Ref the file explicitly in the entrypoint

We're choosing the latter here. It's more explicit, has a smaller test/support surface, is marginally more efficient, is more likely to handle signals correctly, and (I'm told) is the preferred practice in the industry.

Override as:

`podman run ... -v /path/to/local.toml:/mcp_config.toml:z ...`

...where the `:/mcp_config.toml` part has to be exact, as that's where the entrypoint is telling the binary to look.