### PR TITLE
NO-JIRA: label tracing tasks with suite observability

### DIFF
--- a/evals/tasks/observability/traces/latency-investigation.yaml
+++ b/evals/tasks/observability/traces/latency-investigation.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: traces
+    suite: observability
     toolType: query
   description: |
     Tests if the agent can find high latency traces for a specific service

--- a/evals/tasks/observability/traces/search-error-traces.yaml
+++ b/evals/tasks/observability/traces/search-error-traces.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: traces
+    suite: observability
     toolType: query
   description: |
     Tests if the agent can discover Tempo instances and search for


### PR DESCRIPTION
Align tracing eval tasks with the metrics suite so they are picked up by the observability task set in eval configs.

cc: @andreasgerstmayr 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated evaluation task configurations to improve organization of observability-related testing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->