### PR TITLE
docs: fix unsupported auth combination in Entra ID setup

### DIFF
--- a/docs/ENTRA_ID_SETUP.md
+++ b/docs/ENTRA_ID_SETUP.md
@@ -124,20 +124,15 @@ Replace:
 If your Kubernetes cluster doesn't accept Entra ID tokens on the API server, use this configuration:
 
 ```toml
-require_oauth = true
-oauth_audience = "<CLIENT_ID>"
-oauth_scopes = ["openid", "profile", "email"]
-
-authorization_url = "https://login.microsoftonline.com/<TENANT_ID>/v2.0"
-
 # Use kubeconfig ServiceAccount credentials for cluster access
 cluster_auth_mode = "kubeconfig"
 kubeconfig = "/path/to/sa-kubeconfig"
 ```
 
 This setup:
-- **MCP clients authenticate via Entra ID** (OAuth required for MCP access)
 - **Cluster access uses ServiceAccount token** (from kubeconfig)
+
+> **Note:** `require_oauth = true` is incompatible with `cluster_auth_mode = "kubeconfig"` and is rejected at startup.
 
 #### Creating a ServiceAccount Kubeconfig
 


### PR DESCRIPTION
The "With ServiceAccount Credentials" section showed require_oauth=true with cluster_auth_mode="kubeconfig", which the server rejects at startup because all users would share a single cluster identity, breaking per-user audit trails.

Remove the invalid OAuth config from the example and add a note explaining the constraint.

Fixes #328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Entra ID configuration documentation with clarified examples for kubeconfig authentication mode. Simplified configuration snippets by removing incompatible OAuth settings and added explicit guidance on configuration constraints to help users configure the system correctly and avoid startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->