### PR TITLE
NO-JIRA: Update Dockerfile metadata from OLS to OCP MCP Server

### DIFF
--- a/.konflux_release/README.md
+++ b/.konflux_release/README.md
@@ -1,0 +1,61 @@
+# Konflux Release Artifacts
+
+This directory contains the Konflux release artifacts used to promote builds of
+this repository.
+
+## What these resources mean
+
+- `Snapshot`: a point-in-time capture of the component image, source revision,
+  and related build inputs that should be released together.
+- `ReleasePlan`: the developer-side configuration that declares where the
+  application can be promoted and which managed-side admission should process
+  it.
+- `Release`: the concrete release request that promotes one snapshot through one
+  release plan.
+- `ReleasePlanAdmission`: the managed-side policy and pipeline configuration.
+  It is managed outside this repository in the Konflux configuration repo, so
+  it is not stored under `.konflux_release/`.
+
+## Layout
+
+- `releasePlan/`: developer-side `ReleasePlan` manifests
+- `snapshot/`: `Snapshot` manifests that pin the exact image digest and source
+  revision to release
+- `releases/`: `Release` manifests that request promotion of a snapshot through
+  a release plan
+
+The exact filenames may change over time as new release requests are created.
+
+## High-Level Flow
+
+1. Build pipelines produce an image that should be promoted.
+2. A `Snapshot` captures the exact image digest, component name, and source
+   revision for that build.
+3. A `ReleasePlan` defines the developer-side promotion intent.
+4. A `Release` references both the `Snapshot` and the `ReleasePlan` to request
+   promotion.
+5. Konflux matches that `ReleasePlan` with the corresponding
+   `ReleasePlanAdmission` from the Konflux config repo and executes the managed
+   release process.
+
+## Typical usage
+
+1. Update or create a `Snapshot` with the image digest and source revision you
+   want to promote.
+2. Apply or update the developer-side `ReleasePlan` if needed.
+3. Create a new `Release` that references the chosen `Snapshot` and
+   `ReleasePlan`.
+
+```bash
+kubectl apply -f .konflux_release/releasePlan/<release-plan>.yaml
+kubectl apply -f .konflux_release/snapshot/<snapshot>.yaml
+kubectl create -f .konflux_release/releases/<release>.yaml
+```
+
+## Notes
+
+- Snapshots should reference container images by digest, not by tag.
+- `ReleasePlanAdmission` is owned in the Konflux config repo, not in this
+  application repo.
+- Create a new manifest under `releases/` for each manual release request
+  instead of reusing an old `Release` object.

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=registry.redhat.io/ubi9/go-toolset:1.26.3
+ARG BUILDER_IMAGE=registry.redhat.io/ubi9/go-toolset:1.26
 ARG BASE_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:latest
 
 # Build the manager binary
@@ -23,20 +23,21 @@ COPY --from=builder /workspace/LICENSE /licenses/.
 USER 65532:65532
 
 COPY mcp_config.toml /mcp_config.toml
+ENV CONFIG_PATH=/mcp_config.toml
 
 # Labels for enterprise contract
 LABEL com.redhat.component=openshift-mcp-server
-LABEL cpe="cpe:/a:redhat:openshift_lightspeed:1::el9"
-LABEL description="Red Hat OpenShift MCP Server"
-LABEL io.k8s.description="Red Hat OpenShift MCP Server"
-LABEL io.k8s.display-name="Red Hat OpenShift MCP Server"
+LABEL cpe="cpe:/a:redhat:openshift_mcp_server:0.3::el9"
+LABEL description="MCP server for Red Hat OpenShift"
+LABEL io.k8s.description="MCP server for Red Hat OpenShift"
+LABEL io.k8s.display-name="MCP server for Red Hat OpenShift"
 LABEL io.openshift.tags="openshift,mcp"
-LABEL name="openshift-lightspeed/openshift-mcp-server-rhel9"
-LABEL release=0.0.1
+LABEL name="openshift-mcp-tech-preview/openshift-mcp-server-rhel9"
+LABEL release=0.3.0
 LABEL url="https://github.com/openshift/openshift-mcp-server"
 LABEL vendor="Red Hat, Inc."
-LABEL version=0.0.1
-LABEL summary="Red Hat OpenShift MCP Server"
+LABEL version=0.3.0
+LABEL summary="MCP server for Red Hat OpenShift"
 LABEL konflux.additional-tags="latest"
 
-ENTRYPOINT ["/openshift-mcp-server", "--config", "/mcp_config.toml"]
+ENTRYPOINT ["/openshift-mcp-server", "--config", "$CONFIG_PATH"]

--- a/Makefile-ocp.mk
+++ b/Makefile-ocp.mk
@@ -3,3 +3,15 @@ include Makefile
 .PHONY: build-ocp
 build-ocp: clean format
 	CGO_ENABLED=1 $(GO_BUILD_ENV) go build $(COMMON_BUILD_ARGS) -tags=strictfipsruntime -mod=vendor -a -o openshift-mcp-server ./cmd/kubernetes-mcp-server
+
+apply-override-snapshot:
+	kubectl apply -f .konflux_release/snapshot
+.PHONY: apply-override-snapshot
+
+apply-releaseplan:
+	kubectl apply -f .konflux_release/releasePlan
+.PHONY: apply-releaseplan
+
+apply-releases:
+	kubectl apply -f .konflux_release/releases
+.PHONY: apply-releases


### PR DESCRIPTION
## Summary

This PR updates the Dockerfile metadata references from OLS to OCP MCP Server.

## Changes

* Update Dockerfile labels and metadata references
* Replace OLS-related metadata with OCP MCP Server values
* Align image metadata with the current MCP server naming and configuration

cc @matzew @Cali0707 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide documenting Konflux release artifacts, directory structure, and promotion workflow.

* **Chores**
  * Updated container image base toolset and metadata labels.
  * Added build targets for deploying release artifacts to Kubernetes clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->