### PR TITLE
MG-285: Add evals for `openshift/mustgather` toolset

### DIFF
--- a/evals/core-eval-testing/acp-anthropic/eval-mustgather.yaml
+++ b/evals/core-eval-testing/acp-anthropic/eval-mustgather.yaml
@@ -1,0 +1,1 @@
+../builtin-openai/eval-mustgather.yaml

--- a/evals/core-eval-testing/acp-google/eval-mustgather.yaml
+++ b/evals/core-eval-testing/acp-google/eval-mustgather.yaml
@@ -1,0 +1,1 @@
+../builtin-openai/eval-mustgather.yaml

--- a/evals/core-eval-testing/builtin-anthropic/eval-mustgather.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-mustgather.yaml
@@ -1,0 +1,1 @@
+../builtin-openai/eval-mustgather.yaml

--- a/evals/core-eval-testing/builtin-google/eval-mustgather.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-mustgather.yaml
@@ -1,0 +1,1 @@
+../builtin-openai/eval-mustgather.yaml

--- a/evals/core-eval-testing/builtin-openai/eval-all.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-all.yaml
@@ -83,3 +83,13 @@ config:
             toolPattern: "netobserv_.*"
         minToolCalls: 1
         maxToolCalls: 10
+    # Must-gather tasks
+    - glob: ../../tasks/*/*/*.yaml
+      labelSelector:
+        suite: mustgather
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: "mustgather_.*"
+        minToolCalls: 1
+        maxToolCalls: 15

--- a/evals/core-eval-testing/builtin-openai/eval-mustgather.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-mustgather.yaml
@@ -1,0 +1,25 @@
+kind: Eval
+metadata:
+  name: "mustgather-e2e"
+config:
+  agent:
+    type: "file"
+    path: agent.yaml
+  mcpConfigFile: ../../mcp-config.yaml
+  extensions:
+    kubernetes:
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
+  llmJudge:
+    ref:
+      type: file
+      path: agent.yaml
+  taskSets:
+    - glob: ../../tasks/*/*/*.yaml
+      labelSelector:
+        suite: mustgather
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: "mustgather_.*"
+        minToolCalls: 1
+        maxToolCalls: 15

--- a/evals/tasks/mustgather/diagnose-olm-catalog-empty/task.yaml
+++ b/evals/tasks/mustgather/diagnose-olm-catalog-empty/task.yaml
@@ -1,0 +1,80 @@
+kind: Task
+metadata:
+  labels:
+    suite: mustgather
+  name: diagnose-olm-catalog-empty
+  difficulty: hard
+steps:
+  setup:
+    inline: |-
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      # Scale down CVO so it doesn't reconcile the operators back
+      oc scale deployment/cluster-version-operator -n openshift-cluster-version --replicas=0
+      echo "Scaled down CVO"
+
+      # Scale down OLM operator and packageserver
+      oc scale deployment/olm-operator -n openshift-operator-lifecycle-manager --replicas=0
+      oc scale deployment/packageserver -n openshift-operator-lifecycle-manager --replicas=0
+      echo "Scaled down OLM operator and packageserver"
+
+      # Wait for packageserver pods to terminate
+      oc wait --for=delete pod -l app=packageserver -n openshift-operator-lifecycle-manager --timeout=120s 2>/dev/null || true
+      echo "Packageserver pods terminated"
+
+      # Capture apiservice status for verification
+      oc get apiservice v1.packages.operators.coreos.com -o jsonpath='{.status.conditions[0].type}={.status.conditions[0].status}' > /tmp/mustgather-eval-apiservice-status
+      echo "APIService status captured"
+
+      # Collect must-gather from the broken cluster
+      MG_DIR="/tmp/mustgather-eval-olm"
+      rm -rf "${MG_DIR}"
+      mkdir -p "${MG_DIR}"
+      echo "Running oc adm must-gather..."
+      oc adm must-gather --dest-dir="${MG_DIR}" 2>&1
+      echo "Must-gather archive ready at ${MG_DIR}"
+  verify:
+    inline: |-
+      #!/usr/bin/env bash
+      set -euo pipefail
+      # The agent should identify that packageserver is scaled to 0 / not running
+      # and that the v1.packages.operators.coreos.com apiservice is unavailable
+      echo "packageserver"
+  cleanup:
+    inline: |-
+      #!/usr/bin/env bash
+      set -euo pipefail
+      # Restore CVO so it reconciles everything back
+      oc scale deployment/cluster-version-operator -n openshift-cluster-version --replicas=1
+      echo "Restored CVO"
+      # Restore OLM components
+      oc scale deployment/olm-operator -n openshift-operator-lifecycle-manager --replicas=1
+      oc scale deployment/packageserver -n openshift-operator-lifecycle-manager --replicas=2
+      echo "Restored OLM operator and packageserver"
+      # Cleanup
+      rm -rf /tmp/mustgather-eval-olm /tmp/mustgather-eval-apiservice-status
+  prompt:
+    inline: |
+      I have an OpenShift cluster where no operators show up in the OperatorHub catalog
+      when browsing the OpenShift web console. The catalog page is completely empty.
+
+      I have already collected a must-gather archive at /tmp/mustgather-eval-olm.
+
+      Please:
+      1. Load the must-gather archive from /tmp/mustgather-eval-olm using the mustgather_use tool
+      2. Investigate the must-gather data to diagnose why the operator catalog is empty
+      3. Check the status of OLM-related components (deployments, pods, apiservices)
+      4. Identify the root cause and suggest a fix
+
+      Focus on the openshift-operator-lifecycle-manager namespace and the packageserver component.
+  assertions:
+    toolsUsed:
+      - server: kubernetes
+        toolPattern: "mustgather_use"
+        args:
+          path: "/tmp/mustgather-eval-olm"
+      - server: kubernetes
+        toolPattern: "mustgather_resources_.*"
+    minToolCalls: 2
+    maxToolCalls: 15

--- a/evals/tasks/mustgather/resources-list-nodes/task.yaml
+++ b/evals/tasks/mustgather/resources-list-nodes/task.yaml
@@ -1,0 +1,48 @@
+kind: Task
+metadata:
+  labels:
+    suite: mustgather
+  name: resources-list-nodes
+  difficulty: easy
+steps:
+  setup:
+    inline: |-
+      #!/usr/bin/env bash
+      set -euo pipefail
+      MG_DIR="/tmp/mustgather-eval"
+      rm -rf "${MG_DIR}"
+      mkdir -p "${MG_DIR}"
+      echo "Running oc adm must-gather..."
+      oc adm must-gather --dest-dir="${MG_DIR}" 2>&1
+      echo "Must-gather archive ready at ${MG_DIR}"
+      # Save a node name for verification
+      kubectl get nodes -o jsonpath='{.items[0].metadata.name}' > /tmp/mustgather-eval-node-name
+  verify:
+    inline: |-
+      #!/usr/bin/env bash
+      set -euo pipefail
+      EXPECTED_NODE=$(cat /tmp/mustgather-eval-node-name)
+      echo "${EXPECTED_NODE}"
+  cleanup:
+    inline: |-
+      #!/usr/bin/env bash
+      set -euo pipefail
+      rm -rf /tmp/mustgather-eval /tmp/mustgather-eval-node-name
+  prompt:
+    inline: |
+      I have a must-gather archive extracted at /tmp/mustgather-eval. Please:
+      1. Load the must-gather archive from /tmp/mustgather-eval using the mustgather_use tool
+      2. List all Node resources from the archive using the mustgather_resources_list tool with kind "Node"
+      Report the node names and count.
+  assertions:
+    toolsUsed:
+      - server: kubernetes
+        toolPattern: "mustgather_use"
+        args:
+          path: "/tmp/mustgather-eval"
+      - server: kubernetes
+        toolPattern: "mustgather_resources_list"
+        args:
+          kind: "Node"
+    minToolCalls: 2
+    maxToolCalls: 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added evaluation coverage for loading must-gather archives and listing Kubernetes node resources.
  * Added diagnostic evaluation for identifying an unavailable packages API service and stopped package server.
  * Included must-gather evaluations in the full end-to-end test suite.
  * Enabled must-gather tools by default, including diagnostics, event queries, monitoring data, and pod logs.

* **Tests**
  * Expanded validation of must-gather tool usage, arguments, and call limits.
  * Standardized must-gather evaluation configurations across supported evaluation environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->