### PR TITLE
OCPMCP-330: [release-0.3] bump Go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/kubernetes-mcp-server
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
bump to latest of downstream 1.25.x `go` version 