### PR TITLE
feat(kubevirt): add vm_troubleshoot as an MCP Tool

### DIFF
--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -233,5 +233,34 @@
     },
     "name": "vm_lifecycle",
     "title": "Virtual Machine: Lifecycle"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Virtual Machine: Troubleshoot"
+    },
+    "description": "Diagnose KubeVirt VirtualMachine issues by collecting VM status, VMI status, volumes, virt-launcher pod state, pod logs, and related events. Returns a structured diagnostic report. Use this tool whenever a user asks why a VM is not starting, crashing, failing to migrate, or exhibiting unexpected behavior. This tool should be invoked proactively in troubleshooting mode.",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "The name of the VirtualMachine to troubleshoot",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace of the VirtualMachine to troubleshoot",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "vm_troubleshoot",
+    "title": "Virtual Machine: Troubleshoot"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -242,7 +242,7 @@
       "readOnlyHint": true,
       "title": "Virtual Machine: Troubleshoot"
     },
-    "description": "Diagnose KubeVirt VirtualMachine issues by collecting VM status, VMI status, volumes, virt-launcher pod state, pod logs, and related events. Returns a structured diagnostic report. Use this tool whenever a user asks why a VM is not starting, crashing, failing to migrate, or exhibiting unexpected behavior. This tool should be invoked proactively in troubleshooting mode.",
+    "description": "Diagnose KubeVirt VirtualMachine issues by collecting VM status, VMI status, volumes, DataVolume/PVC state, cloud-init configuration, virt-launcher pod state, pod logs, and related events. Returns a structured diagnostic report with root-cause data that goes beyond what alerts provide. Use this tool FIRST whenever a user asks why a VM is not starting, stuck in Provisioning, crashlooping, failing to migrate, or exhibiting unexpected behavior. Identifies issues such as missing StorageClasses, invalid PVC specs, misconfigured cloud-init, and scheduling constraints.",
     "inputSchema": {
       "properties": {
         "name": {

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -10,6 +10,7 @@ import (
 	vm_create "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/create"
 	vm_guestagent "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/guestagent"
 	vm_lifecycle "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/lifecycle"
+	vm_troubleshoot "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/troubleshoot"
 )
 
 type Toolset struct{}
@@ -30,6 +31,7 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 		vm_create.Tools(),
 		vm_guestagent.Tools(),
 		vm_lifecycle.Tools(),
+		vm_troubleshoot.Tools(),
 	)
 }
 

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
@@ -23,9 +23,10 @@ func Tools() []api.ServerTool {
 			Tool: api.Tool{
 				Name: "vm_troubleshoot",
 				Description: fmt.Sprintf(
-					"Diagnose %s VirtualMachine issues by collecting VM status, VMI status, volumes, virt-launcher pod state, pod logs, and related events. "+
-						"Returns a structured diagnostic report. Use this tool whenever a user asks why a VM is not starting, crashing, failing to migrate, or exhibiting unexpected behavior. "+
-						"This tool should be invoked proactively in troubleshooting mode.",
+					"Diagnose %s VirtualMachine issues by collecting VM status, VMI status, volumes, DataVolume/PVC state, cloud-init configuration, virt-launcher pod state, pod logs, and related events. "+
+						"Returns a structured diagnostic report with root-cause data that goes beyond what alerts provide. "+
+						"Use this tool FIRST whenever a user asks why a VM is not starting, stuck in Provisioning, crashlooping, failing to migrate, or exhibiting unexpected behavior. "+
+						"Identifies issues such as missing StorageClasses, invalid PVC specs, misconfigured cloud-init, and scheduling constraints.",
 					defaults.ProductName()),
 				InputSchema: &jsonschema.Schema{
 					Type: "object",
@@ -75,6 +76,8 @@ func troubleshoot(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	vmYaml, vm := fetchVMStatus(ctx, dynamicClient, namespace, name)
 	vmiYaml, vmi := fetchVMIStatus(ctx, dynamicClient, namespace, name)
 	volumesYaml := fetchVolumes(namespace, name, vm, vmi)
+	dataVolumeYaml := fetchDataVolumeStatus(ctx, dynamicClient, namespace, vm)
+	cloudInitYaml := extractCloudInit(vm, vmi)
 	podYaml, podNames := fetchVirtLauncherPod(ctx, dynamicClient, namespace, name)
 	podLogsText := fetchVirtLauncherPodLogs(ctx, params.KubernetesClient, namespace, podNames)
 	eventsYaml := fetchEvents(ctx, params.KubernetesClient, namespace, name)
@@ -92,7 +95,11 @@ func troubleshoot(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 %s
 
 %s
-`, namespace, name, vmYaml, vmiYaml, volumesYaml, podYaml, podLogsText, eventsYaml)
+
+%s
+
+%s
+`, namespace, name, vmYaml, vmiYaml, volumesYaml, dataVolumeYaml, cloudInitYaml, podYaml, podLogsText, eventsYaml)
 
 	return api.NewToolCallResult(report, nil), nil
 }
@@ -274,4 +281,132 @@ func fetchEvents(ctx context.Context, client api.KubernetesClient, namespace, vm
 	}
 
 	return fmt.Sprintf("## Events (related to %s)\n\n```yaml\n%s```", vmName, yamlStr)
+}
+
+func fetchDataVolumeStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace string, vm *unstructured.Unstructured) string {
+	if vm == nil {
+		return "## DataVolume/PVC Status\n\n*No VM available to extract DataVolume references*"
+	}
+
+	dvTemplates, found, err := unstructured.NestedSlice(vm.Object, "spec", "dataVolumeTemplates")
+	if err != nil || !found || len(dvTemplates) == 0 {
+		return "## DataVolume/PVC Status\n\n*No dataVolumeTemplates defined in VM spec*"
+	}
+
+	var result strings.Builder
+	result.WriteString("## DataVolume/PVC Status\n\n")
+
+	for _, dvTemplate := range dvTemplates {
+		dvMap, ok := dvTemplate.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		metadata, _ := dvMap["metadata"].(map[string]interface{})
+		dvName, _ := metadata["name"].(string)
+		if dvName == "" {
+			continue
+		}
+
+		dv, err := dynamicClient.Resource(kubevirt.DataVolumeGVR).Namespace(namespace).Get(ctx, dvName, metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(&result, "### %s\n\n*DataVolume not found: %v*\n\n", dvName, err)
+			pvc, pvcErr := dynamicClient.Resource(kubevirt.PersistentVolumeClaimGVR).Namespace(namespace).Get(ctx, dvName, metav1.GetOptions{})
+			if pvcErr != nil {
+				fmt.Fprintf(&result, "*PVC also not found: %v*\n\n", pvcErr)
+			} else {
+				pvcStatus, _, _ := unstructured.NestedMap(pvc.Object, "status")
+				if pvcStatus != nil {
+					yamlStr, _ := output.MarshalYaml(pvcStatus)
+					fmt.Fprintf(&result, "PVC exists with status:\n```yaml\n%s```\n\n", yamlStr)
+				}
+			}
+			continue
+		}
+
+		dvStatus, found, _ := unstructured.NestedMap(dv.Object, "status")
+		if !found {
+			fmt.Fprintf(&result, "### %s\n\n*DataVolume exists but has no status*\n\n", dvName)
+			continue
+		}
+
+		yamlStr, err := output.MarshalYaml(dvStatus)
+		if err != nil {
+			fmt.Fprintf(&result, "### %s\n\n*Error marshaling DataVolume status: %v*\n\n", dvName, err)
+			continue
+		}
+
+		dvSpec, _, _ := unstructured.NestedMap(dv.Object, "spec")
+		storageClass := ""
+		if dvSpec != nil {
+			sc, _, _ := unstructured.NestedString(dvSpec, "storage", "storageClassName")
+			if sc != "" {
+				storageClass = sc
+			}
+		}
+
+		fmt.Fprintf(&result, "### %s", dvName)
+		if storageClass != "" {
+			fmt.Fprintf(&result, " (storageClass: %s)", storageClass)
+		}
+		fmt.Fprintf(&result, "\n\n```yaml\n%s```\n\n", yamlStr)
+	}
+
+	return result.String()
+}
+
+func extractCloudInit(vm, vmi *unstructured.Unstructured) string {
+	var volumes []interface{}
+	if vm != nil {
+		volumes, _, _ = unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	}
+	if len(volumes) == 0 && vmi != nil {
+		volumes, _, _ = unstructured.NestedSlice(vmi.Object, "spec", "volumes")
+	}
+	if len(volumes) == 0 {
+		return "## Cloud-Init Configuration\n\n*No volumes found*"
+	}
+
+	var result strings.Builder
+	found := false
+
+	for _, vol := range volumes {
+		volMap, ok := vol.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, ciKey := range []string{"cloudInitNoCloud", "cloudInitConfigDrive"} {
+			ciData, exists := volMap[ciKey].(map[string]interface{})
+			if !exists {
+				continue
+			}
+			found = true
+			if result.Len() == 0 {
+				result.WriteString("## Cloud-Init Configuration\n\n")
+			}
+
+			volName, _ := volMap["name"].(string)
+			fmt.Fprintf(&result, "### %s (type: %s)\n\n", volName, ciKey)
+
+			userData, _ := ciData["userData"].(string)
+			if userData != "" {
+				fmt.Fprintf(&result, "```yaml\n%s\n```\n\n", userData)
+			}
+			networkData, _ := ciData["networkData"].(string)
+			if networkData != "" {
+				fmt.Fprintf(&result, "**networkData:**\n```yaml\n%s\n```\n\n", networkData)
+			}
+			if userData == "" && networkData == "" {
+				secretRef, _ := ciData["userDataSecretRef"].(map[string]interface{})
+				if secretRef != nil {
+					fmt.Fprintf(&result, "*userData from Secret: %v*\n\n", secretRef["name"])
+				}
+			}
+		}
+	}
+
+	if !found {
+		return "## Cloud-Init Configuration\n\n*No cloud-init volumes configured*"
+	}
+	return result.String()
 }

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/ptr"
 )
@@ -80,7 +81,7 @@ func troubleshoot(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	cloudInitYaml := extractCloudInit(vm, vmi)
 	podYaml, podNames := fetchVirtLauncherPod(ctx, dynamicClient, namespace, name)
 	podLogsText := fetchVirtLauncherPodLogs(ctx, params.KubernetesClient, namespace, podNames)
-	eventsYaml := fetchEvents(ctx, params.KubernetesClient, namespace, name)
+	eventsYaml := fetchEvents(ctx, params.KubernetesClient, namespace, name, podNames)
 
 	report := fmt.Sprintf(`# VirtualMachine Diagnostic Report: %s/%s
 
@@ -234,41 +235,21 @@ func fetchVirtLauncherPodLogs(ctx context.Context, client api.KubernetesClient, 
 	return result.String()
 }
 
-func fetchEvents(ctx context.Context, client api.KubernetesClient, namespace, vmName string) string {
+func fetchEvents(ctx context.Context, client api.KubernetesClient, namespace, vmName string, podNames []string) string {
 	core := kubernetes.NewCore(client)
 
-	vmEvents, err := core.EventsList(ctx, namespace, api.ListOptions{
-		ListOptions: metav1.ListOptions{FieldSelector: "involvedObject.name=" + vmName},
-	})
-	if err != nil {
-		return fmt.Sprintf("## Events\n\n*Error listing events: %v*", err)
-	}
+	objectNames := []string{vmName}
+	objectNames = append(objectNames, podNames...)
 
 	var relatedEvents []map[string]any
-	for _, event := range vmEvents {
-		involvedObj, ok := event["InvolvedObject"].(map[string]string)
-		if !ok {
+	for _, objName := range objectNames {
+		events, err := core.EventsList(ctx, namespace, api.ListOptions{
+			ListOptions: metav1.ListOptions{FieldSelector: "involvedObject.name=" + objName},
+		})
+		if err != nil {
 			continue
 		}
-		objKind := involvedObj["Kind"]
-		if objKind == "VirtualMachine" || objKind == "VirtualMachineInstance" {
-			relatedEvents = append(relatedEvents, event)
-		}
-	}
-
-	allEvents, err := core.EventsList(ctx, namespace, api.ListOptions{})
-	if err != nil {
-		return fmt.Sprintf("## Events\n\n*Error listing events: %v*", err)
-	}
-	for _, event := range allEvents {
-		involvedObj, ok := event["InvolvedObject"].(map[string]string)
-		if !ok {
-			continue
-		}
-		objName := involvedObj["Name"]
-		if strings.HasPrefix(objName, vmName+"-") || strings.HasPrefix(objName, "virt-launcher-"+vmName) {
-			relatedEvents = append(relatedEvents, event)
-		}
+		relatedEvents = append(relatedEvents, events...)
 	}
 
 	if len(relatedEvents) == 0 {
@@ -309,7 +290,11 @@ func fetchDataVolumeStatus(ctx context.Context, dynamicClient dynamic.Interface,
 
 		dv, err := dynamicClient.Resource(kubevirt.DataVolumeGVR).Namespace(namespace).Get(ctx, dvName, metav1.GetOptions{})
 		if err != nil {
-			fmt.Fprintf(&result, "### %s\n\n*DataVolume not found: %v*\n\n", dvName, err)
+			if !apierrors.IsNotFound(err) {
+				fmt.Fprintf(&result, "### %s\n\n*Error fetching DataVolume: %v*\n\n", dvName, err)
+				continue
+			}
+			fmt.Fprintf(&result, "### %s\n\n*DataVolume not found*\n\n", dvName)
 			pvc, pvcErr := dynamicClient.Resource(kubevirt.PersistentVolumeClaimGVR).Namespace(namespace).Get(ctx, dvName, metav1.GetOptions{})
 			if pvcErr != nil {
 				fmt.Fprintf(&result, "*PVC also not found: %v*\n\n", pvcErr)
@@ -390,11 +375,11 @@ func extractCloudInit(vm, vmi *unstructured.Unstructured) string {
 
 			userData, _ := ciData["userData"].(string)
 			if userData != "" {
-				fmt.Fprintf(&result, "```yaml\n%s\n```\n\n", userData)
+				fmt.Fprintf(&result, "```yaml\n%s\n```\n\n", redactCloudInitSensitiveFields(userData))
 			}
 			networkData, _ := ciData["networkData"].(string)
 			if networkData != "" {
-				fmt.Fprintf(&result, "**networkData:**\n```yaml\n%s\n```\n\n", networkData)
+				fmt.Fprintf(&result, "**networkData:** *present (%d bytes, redacted for security)*\n\n", len(networkData))
 			}
 			if userData == "" && networkData == "" {
 				secretRef, _ := ciData["userDataSecretRef"].(map[string]interface{})
@@ -409,4 +394,50 @@ func extractCloudInit(vm, vmi *unstructured.Unstructured) string {
 		return "## Cloud-Init Configuration\n\n*No cloud-init volumes configured*"
 	}
 	return result.String()
+}
+
+var sensitiveCloudInitKeys = []string{
+	"password:",
+	"passwd:",
+	"ssh_authorized_keys:",
+	"ssh-rsa ",
+	"ssh-ed25519 ",
+	"ecdsa-sha2-",
+	"ca-cert:",
+	"client-cert:",
+	"client-key:",
+	"token:",
+	"secret:",
+}
+
+func redactCloudInitSensitiveFields(userData string) string {
+	lines := strings.Split(userData, "\n")
+	var result []string
+	redacting := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		isSensitive := false
+		for _, key := range sensitiveCloudInitKeys {
+			if strings.Contains(strings.ToLower(trimmed), strings.ToLower(key)) {
+				isSensitive = true
+				break
+			}
+		}
+
+		if isSensitive {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " "))]
+			keyPart := strings.SplitN(trimmed, ":", 2)[0]
+			result = append(result, indent+keyPart+": <REDACTED>")
+			redacting = strings.HasSuffix(trimmed, "|") || strings.HasSuffix(trimmed, ">")
+		} else if redacting {
+			if len(trimmed) > 0 && !strings.HasPrefix(trimmed, "-") && trimmed[0] != ' ' {
+				redacting = false
+				result = append(result, line)
+			}
+		} else {
+			result = append(result, line)
+		}
+	}
+	return strings.Join(result, "\n")
 }

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
@@ -1,0 +1,277 @@
+package troubleshoot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+	"github.com/google/jsonschema-go/jsonschema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
+)
+
+func Tools() []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name: "vm_troubleshoot",
+				Description: fmt.Sprintf(
+					"Diagnose %s VirtualMachine issues by collecting VM status, VMI status, volumes, virt-launcher pod state, pod logs, and related events. "+
+						"Returns a structured diagnostic report. Use this tool whenever a user asks why a VM is not starting, crashing, failing to migrate, or exhibiting unexpected behavior. "+
+						"This tool should be invoked proactively in troubleshooting mode.",
+					defaults.ProductName()),
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "The namespace of the VirtualMachine to troubleshoot",
+						},
+						"name": {
+							Type:        "string",
+							Description: "The name of the VirtualMachine to troubleshoot",
+						},
+					},
+					Required: []string{"namespace", "name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Virtual Machine: Troubleshoot",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: troubleshoot,
+		},
+	}
+}
+
+func troubleshoot(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	namespace, err := api.RequiredString(params, "namespace")
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	name, err := api.RequiredString(params, "name")
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	ctx := params.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	dynamicClient := params.DynamicClient()
+
+	vmYaml, vm := fetchVMStatus(ctx, dynamicClient, namespace, name)
+	vmiYaml, vmi := fetchVMIStatus(ctx, dynamicClient, namespace, name)
+	volumesYaml := fetchVolumes(namespace, name, vm, vmi)
+	podYaml, podNames := fetchVirtLauncherPod(ctx, dynamicClient, namespace, name)
+	podLogsText := fetchVirtLauncherPodLogs(ctx, params.KubernetesClient, namespace, podNames)
+	eventsYaml := fetchEvents(ctx, params.KubernetesClient, namespace, name)
+
+	report := fmt.Sprintf(`# VirtualMachine Diagnostic Report: %s/%s
+
+%s
+
+%s
+
+%s
+
+%s
+
+%s
+
+%s
+`, namespace, name, vmYaml, vmiYaml, volumesYaml, podYaml, podLogsText, eventsYaml)
+
+	return api.NewToolCallResult(report, nil), nil
+}
+
+func fetchVMStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (string, *unstructured.Unstructured) {
+	vm, err := dynamicClient.Resource(kubevirt.VirtualMachineGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachine\n\n*Error: %v*", err), nil
+	}
+
+	status, found, err := unstructured.NestedMap(vm.Object, "status")
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachine\n\n*Error extracting status: %v*", err), vm
+	}
+	if !found {
+		return fmt.Sprintf("## VirtualMachine: %s/%s\n\n*No status found (VM may not have been reconciled yet)*", namespace, name), vm
+	}
+
+	yamlStr, err := output.MarshalYaml(status)
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachine\n\n*Error marshaling status: %v*", err), vm
+	}
+
+	return fmt.Sprintf("## VirtualMachine Status: %s/%s\n\n```yaml\n%s```", namespace, name, yamlStr), vm
+}
+
+func fetchVMIStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (string, *unstructured.Unstructured) {
+	vmi, err := dynamicClient.Resource(kubevirt.VirtualMachineInstanceGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachineInstance\n\n*VMI not found: %v*\n\n(Expected if VM is stopped or stuck provisioning)", err), nil
+	}
+
+	status, found, err := unstructured.NestedMap(vmi.Object, "status")
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachineInstance\n\n*Error extracting status: %v*", err), vmi
+	}
+	if !found {
+		return fmt.Sprintf("## VirtualMachineInstance: %s/%s\n\n*No status found*", namespace, name), vmi
+	}
+
+	yamlStr, err := output.MarshalYaml(status)
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachineInstance\n\n*Error marshaling status: %v*", err), vmi
+	}
+
+	return fmt.Sprintf("## VirtualMachineInstance Status: %s/%s\n\n```yaml\n%s```", namespace, name, yamlStr), vmi
+}
+
+func fetchVolumes(namespace, name string, vm, vmi *unstructured.Unstructured) string {
+	var volumes []any
+	var found bool
+	var err error
+	source := "VirtualMachine"
+
+	if vm != nil {
+		volumes, found, err = unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+		if err != nil {
+			return "*Error extracting volumes from VirtualMachine: " + err.Error() + "*"
+		}
+	}
+
+	if (!found || len(volumes) == 0) && vmi != nil {
+		volumes, found, err = unstructured.NestedSlice(vmi.Object, "spec", "volumes")
+		if err != nil {
+			return "*Error extracting volumes from VirtualMachineInstance: " + err.Error() + "*"
+		}
+		if found && len(volumes) > 0 {
+			source = "VirtualMachineInstance"
+		}
+	}
+
+	if !found || len(volumes) == 0 {
+		return "## Volumes\n\n*No volumes configured*"
+	}
+
+	yamlStr, err := output.MarshalYaml(volumes)
+	if err != nil {
+		return "*Error marshaling volumes: " + err.Error() + "*"
+	}
+
+	return fmt.Sprintf("## Volumes (from %s: %s/%s)\n\n```yaml\n%s```", source, namespace, name, yamlStr)
+}
+
+func fetchVirtLauncherPod(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (string, []string) {
+	labelSelector := fmt.Sprintf("kubevirt.io=virt-launcher,vm.kubevirt.io/name=%s", name)
+	podList, err := dynamicClient.Resource(kubevirt.PodGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return fmt.Sprintf("## virt-launcher Pod\n\n*Error listing pods: %v*", err), nil
+	}
+
+	if len(podList.Items) == 0 {
+		return "## virt-launcher Pod\n\n*No virt-launcher pod found (VM may be stopped or not yet scheduled)*", nil
+	}
+
+	var result strings.Builder
+	var podNames []string
+	result.WriteString("## virt-launcher Pod\n\n")
+	for _, pod := range podList.Items {
+		podNames = append(podNames, pod.GetName())
+		yamlStr, err := output.MarshalYaml(&pod)
+		if err != nil {
+			fmt.Fprintf(&result, "*Error marshaling pod %s: %v*\n\n", pod.GetName(), err)
+			continue
+		}
+		fmt.Fprintf(&result, "### %s\n\n```yaml\n%s```\n\n", pod.GetName(), yamlStr)
+	}
+
+	return result.String(), podNames
+}
+
+func fetchVirtLauncherPodLogs(ctx context.Context, client api.KubernetesClient, namespace string, podNames []string) string {
+	if len(podNames) == 0 {
+		return "## virt-launcher Pod Logs\n\n*No pod found — no logs available*"
+	}
+
+	core := kubernetes.NewCore(client)
+	var result strings.Builder
+	result.WriteString("## virt-launcher Pod Logs\n\n")
+
+	containerName := "compute"
+	for _, podName := range podNames {
+		logs, err := core.PodsLog(ctx, namespace, podName, containerName, false, 50)
+		if err != nil {
+			fmt.Fprintf(&result, "### %s\n\n*Error fetching logs: %v*\n\n", podName, err)
+			continue
+		}
+		fmt.Fprintf(&result, "### %s (container: %s)\n\n```\n%s\n```\n\n", podName, containerName, logs)
+	}
+
+	return result.String()
+}
+
+func fetchEvents(ctx context.Context, client api.KubernetesClient, namespace, vmName string) string {
+	core := kubernetes.NewCore(client)
+
+	vmEvents, err := core.EventsList(ctx, namespace, api.ListOptions{
+		ListOptions: metav1.ListOptions{FieldSelector: "involvedObject.name=" + vmName},
+	})
+	if err != nil {
+		return fmt.Sprintf("## Events\n\n*Error listing events: %v*", err)
+	}
+
+	var relatedEvents []map[string]any
+	for _, event := range vmEvents {
+		involvedObj, ok := event["InvolvedObject"].(map[string]string)
+		if !ok {
+			continue
+		}
+		objKind := involvedObj["Kind"]
+		if objKind == "VirtualMachine" || objKind == "VirtualMachineInstance" {
+			relatedEvents = append(relatedEvents, event)
+		}
+	}
+
+	allEvents, err := core.EventsList(ctx, namespace, api.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("## Events\n\n*Error listing events: %v*", err)
+	}
+	for _, event := range allEvents {
+		involvedObj, ok := event["InvolvedObject"].(map[string]string)
+		if !ok {
+			continue
+		}
+		objName := involvedObj["Name"]
+		if strings.HasPrefix(objName, vmName+"-") || strings.HasPrefix(objName, "virt-launcher-"+vmName) {
+			relatedEvents = append(relatedEvents, event)
+		}
+	}
+
+	if len(relatedEvents) == 0 {
+		return "## Events\n\n*No events found related to this VM*"
+	}
+
+	yamlStr, err := output.MarshalYaml(relatedEvents)
+	if err != nil {
+		return fmt.Sprintf("## Events\n\n*Error marshaling events: %v*", err)
+	}
+
+	return fmt.Sprintf("## Events (related to %s)\n\n```yaml\n%s```", vmName, yamlStr)
+}

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
@@ -46,9 +46,13 @@ func (s *TroubleshootToolSuite) TestToolRegistration() {
 		s.ElementsMatch([]string{"namespace", "name"}, schema.Required)
 	})
 
-	s.Run("description mentions proactive invocation", func() {
+	s.Run("description mentions priority and scope", func() {
 		tools := Tools()
-		s.Contains(tools[0].Tool.Description, "proactively")
+		desc := tools[0].Tool.Description
+		s.Contains(desc, "FIRST")
+		s.Contains(desc, "root-cause")
+		s.Contains(desc, "StorageClasses")
+		s.Contains(desc, "cloud-init")
 	})
 }
 
@@ -312,6 +316,223 @@ func (s *TroubleshootToolSuite) TestFetchVirtLauncherPodLogs() {
 	s.Run("returns message when empty pod names", func() {
 		result := fetchVirtLauncherPodLogs(context.Background(), nil, "test-ns", []string{})
 		s.Contains(result, "No pod found")
+	})
+}
+
+func (s *TroubleshootToolSuite) TestFetchDataVolumeStatus() {
+	ctx := context.Background()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		kubevirt.DataVolumeGVR:            "DataVolumeList",
+		kubevirt.PersistentVolumeClaimGVR: "PersistentVolumeClaimList",
+	}
+
+	s.Run("returns DV status when DataVolume exists", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"dataVolumeTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "test-vm-volume",
+						},
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"storageClassName": "premium-storage",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		testDV := &unstructured.Unstructured{}
+		testDV.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "cdi.kubevirt.io/v1beta1",
+			"kind":       "DataVolume",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm-volume",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"storage": map[string]interface{}{
+					"storageClassName": "premium-storage",
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Succeeded",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+				},
+			},
+		})
+
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, testDV)
+		result := fetchDataVolumeStatus(ctx, client, "test-ns", testVM)
+
+		s.Contains(result, "## DataVolume/PVC Status")
+		s.Contains(result, "test-vm-volume")
+		s.Contains(result, "premium-storage")
+		s.Contains(result, "Succeeded")
+	})
+
+	s.Run("returns not found when DataVolume missing", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"dataVolumeTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "missing-volume",
+						},
+					},
+				},
+			},
+		})
+
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+		result := fetchDataVolumeStatus(ctx, client, "test-ns", testVM)
+
+		s.Contains(result, "## DataVolume/PVC Status")
+		s.Contains(result, "missing-volume")
+		s.Contains(result, "not found")
+	})
+
+	s.Run("returns message when VM is nil", func() {
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+		result := fetchDataVolumeStatus(ctx, client, "test-ns", nil)
+
+		s.Contains(result, "No VM available")
+	})
+
+	s.Run("returns message when no dataVolumeTemplates", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{},
+		})
+
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+		result := fetchDataVolumeStatus(ctx, client, "test-ns", testVM)
+
+		s.Contains(result, "No dataVolumeTemplates")
+	})
+}
+
+func (s *TroubleshootToolSuite) TestExtractCloudInit() {
+	s.Run("extracts cloudInitNoCloud userData", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - [\"shutdown\", \"-h\", \"now\"]",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		result := extractCloudInit(testVM, nil)
+
+		s.Contains(result, "## Cloud-Init Configuration")
+		s.Contains(result, "cloudinitdisk")
+		s.Contains(result, "cloudInitNoCloud")
+		s.Contains(result, "shutdown")
+	})
+
+	s.Run("returns no cloud-init message when none configured", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "rootdisk",
+								"containerDisk": map[string]interface{}{
+									"image": "quay.io/containerdisks/fedora:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		result := extractCloudInit(testVM, nil)
+
+		s.Contains(result, "No cloud-init volumes configured")
+	})
+
+	s.Run("returns no volumes message when both nil", func() {
+		result := extractCloudInit(nil, nil)
+		s.Contains(result, "No volumes found")
+	})
+
+	s.Run("extracts from VMI when VM has no volumes", func() {
+		testVMI := &unstructured.Unstructured{}
+		testVMI.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"volumes": []interface{}{
+					map[string]interface{}{
+						"name": "cloudinitdisk",
+						"cloudInitConfigDrive": map[string]interface{}{
+							"userData": "#cloud-config\npassword: test",
+						},
+					},
+				},
+			},
+		})
+
+		result := extractCloudInit(nil, testVMI)
+
+		s.Contains(result, "## Cloud-Init Configuration")
+		s.Contains(result, "cloudInitConfigDrive")
+		s.Contains(result, "password: test")
 	})
 }
 

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
@@ -439,7 +439,7 @@ func (s *TroubleshootToolSuite) TestFetchDataVolumeStatus() {
 }
 
 func (s *TroubleshootToolSuite) TestExtractCloudInit() {
-	s.Run("extracts cloudInitNoCloud userData", func() {
+	s.Run("extracts cloudInitNoCloud userData with runcmd visible", func() {
 		testVM := &unstructured.Unstructured{}
 		testVM.SetUnstructuredContent(map[string]interface{}{
 			"apiVersion": "kubevirt.io/v1",
@@ -470,6 +470,40 @@ func (s *TroubleshootToolSuite) TestExtractCloudInit() {
 		s.Contains(result, "cloudinitdisk")
 		s.Contains(result, "cloudInitNoCloud")
 		s.Contains(result, "shutdown")
+	})
+
+	s.Run("redacts sensitive fields in userData", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\npassword: supersecret123\nruncmd:\n  - echo hello\nssh_authorized_keys:\n  - ssh-rsa AAAA...",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		result := extractCloudInit(testVM, nil)
+
+		s.Contains(result, "password: <REDACTED>")
+		s.NotContains(result, "supersecret123")
+		s.Contains(result, "runcmd")
+		s.Contains(result, "echo hello")
+		s.Contains(result, "ssh_authorized_keys: <REDACTED>")
 	})
 
 	s.Run("returns no cloud-init message when none configured", func() {
@@ -521,7 +555,7 @@ func (s *TroubleshootToolSuite) TestExtractCloudInit() {
 					map[string]interface{}{
 						"name": "cloudinitdisk",
 						"cloudInitConfigDrive": map[string]interface{}{
-							"userData": "#cloud-config\npassword: test",
+							"userData": "#cloud-config\nruncmd:\n  - echo hello",
 						},
 					},
 				},
@@ -532,7 +566,7 @@ func (s *TroubleshootToolSuite) TestExtractCloudInit() {
 
 		s.Contains(result, "## Cloud-Init Configuration")
 		s.Contains(result, "cloudInitConfigDrive")
-		s.Contains(result, "password: test")
+		s.Contains(result, "echo hello")
 	})
 }
 

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
@@ -1,0 +1,320 @@
+package troubleshoot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+type TroubleshootToolSuite struct {
+	suite.Suite
+}
+
+func (s *TroubleshootToolSuite) TestToolRegistration() {
+	s.Run("tool is registered", func() {
+		tools := Tools()
+		s.Require().Len(tools, 1, "Expected 1 troubleshoot tool")
+		s.Equal("vm_troubleshoot", tools[0].Tool.Name)
+		s.Equal("Virtual Machine: Troubleshoot", tools[0].Tool.Annotations.Title)
+		s.NotNil(tools[0].Tool.InputSchema)
+		s.NotNil(tools[0].Handler)
+	})
+
+	s.Run("tool has correct annotations", func() {
+		tools := Tools()
+		tool := tools[0].Tool
+
+		s.True(*tool.Annotations.ReadOnlyHint, "troubleshoot should be read-only")
+		s.False(*tool.Annotations.DestructiveHint, "troubleshoot should not be destructive")
+		s.True(*tool.Annotations.IdempotentHint, "troubleshoot should be idempotent")
+		s.True(*tool.Annotations.OpenWorldHint, "troubleshoot should be open-world")
+	})
+
+	s.Run("tool has correct schema", func() {
+		tools := Tools()
+		schema := tools[0].Tool.InputSchema
+
+		s.Require().NotNil(schema.Properties)
+		s.Contains(schema.Properties, "namespace")
+		s.Contains(schema.Properties, "name")
+		s.ElementsMatch([]string{"namespace", "name"}, schema.Required)
+	})
+
+	s.Run("description mentions proactive invocation", func() {
+		tools := Tools()
+		s.Contains(tools[0].Tool.Description, "proactively")
+	})
+}
+
+func (s *TroubleshootToolSuite) TestFetchVMStatus() {
+	ctx := context.Background()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		kubevirt.VirtualMachineGVR: "VirtualMachineList",
+	}
+
+	s.Run("returns status when VM exists", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"status": map[string]interface{}{
+				"printableStatus": "Running",
+				"ready":           true,
+			},
+		})
+
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, testVM)
+		result, vm := fetchVMStatus(ctx, client, "test-ns", "test-vm")
+
+		s.Contains(result, "## VirtualMachine Status: test-ns/test-vm")
+		s.Contains(result, "printableStatus")
+		s.Contains(result, "Running")
+		s.NotNil(vm)
+	})
+
+	s.Run("returns error when VM not found", func() {
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+		result, vm := fetchVMStatus(ctx, client, "test-ns", "nonexistent")
+
+		s.Contains(result, "## VirtualMachine")
+		s.Contains(result, "Error")
+		s.Nil(vm)
+	})
+
+	s.Run("handles VM with no status field", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{},
+		})
+
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, testVM)
+		result, vm := fetchVMStatus(ctx, client, "test-ns", "test-vm")
+
+		s.Contains(result, "No status found")
+		s.NotNil(vm)
+	})
+}
+
+func (s *TroubleshootToolSuite) TestFetchVMIStatus() {
+	ctx := context.Background()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		kubevirt.VirtualMachineInstanceGVR: "VirtualMachineInstanceList",
+	}
+
+	s.Run("returns status when VMI exists", func() {
+		testVMI := &unstructured.Unstructured{}
+		testVMI.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"status": map[string]interface{}{
+				"phase":    "Running",
+				"nodeName": "worker-1",
+			},
+		})
+
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, testVMI)
+		result, vmi := fetchVMIStatus(ctx, client, "test-ns", "test-vm")
+
+		s.Contains(result, "## VirtualMachineInstance Status: test-ns/test-vm")
+		s.Contains(result, "phase")
+		s.Contains(result, "Running")
+		s.NotNil(vmi)
+	})
+
+	s.Run("returns info message when VMI not found", func() {
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+		result, vmi := fetchVMIStatus(ctx, client, "test-ns", "nonexistent")
+
+		s.Contains(result, "## VirtualMachineInstance")
+		s.Contains(result, "not found")
+		s.Nil(vmi)
+	})
+}
+
+func (s *TroubleshootToolSuite) TestFetchVolumes() {
+	s.Run("returns volumes from VM spec", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "rootdisk",
+								"containerDisk": map[string]interface{}{
+									"image": "quay.io/containerdisks/fedora:latest",
+								},
+							},
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - shutdown -h now",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		result := fetchVolumes("test-ns", "test-vm", testVM, nil)
+
+		s.Contains(result, "## Volumes")
+		s.Contains(result, "VirtualMachine")
+		s.Contains(result, "rootdisk")
+		s.Contains(result, "cloudinitdisk")
+	})
+
+	s.Run("falls back to VMI when VM has no volumes", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		})
+
+		testVMI := &unstructured.Unstructured{}
+		testVMI.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"volumes": []interface{}{
+					map[string]interface{}{
+						"name": "rootdisk",
+						"containerDisk": map[string]interface{}{
+							"image": "quay.io/containerdisks/fedora:latest",
+						},
+					},
+				},
+			},
+		})
+
+		result := fetchVolumes("test-ns", "test-vm", testVM, testVMI)
+
+		s.Contains(result, "## Volumes")
+		s.Contains(result, "VirtualMachineInstance")
+		s.Contains(result, "rootdisk")
+	})
+
+	s.Run("returns no volumes message when both nil", func() {
+		result := fetchVolumes("test-ns", "test-vm", nil, nil)
+		s.Contains(result, "No volumes configured")
+	})
+
+	s.Run("returns no volumes when spec is empty", func() {
+		testVM := &unstructured.Unstructured{}
+		testVM.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "test-vm",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		})
+
+		result := fetchVolumes("test-ns", "test-vm", testVM, nil)
+		s.Contains(result, "No volumes configured")
+	})
+}
+
+func (s *TroubleshootToolSuite) TestFetchVirtLauncherPod() {
+	ctx := context.Background()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		kubevirt.PodGVR: "PodList",
+	}
+
+	s.Run("returns pod info when found", func() {
+		testPod := &unstructured.Unstructured{}
+		testPod.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "virt-launcher-test-vm-abc123",
+				"namespace": "test-ns",
+				"labels": map[string]interface{}{
+					"kubevirt.io":         "virt-launcher",
+					"vm.kubevirt.io/name": "test-vm",
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Running",
+			},
+		})
+
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, testPod)
+		result, podNames := fetchVirtLauncherPod(ctx, client, "test-ns", "test-vm")
+
+		s.Contains(result, "## virt-launcher Pod")
+		s.Contains(result, "virt-launcher-test-vm-abc123")
+		s.Require().Len(podNames, 1)
+		s.Equal("virt-launcher-test-vm-abc123", podNames[0])
+	})
+
+	s.Run("returns message when no pod found", func() {
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+		result, podNames := fetchVirtLauncherPod(ctx, client, "test-ns", "test-vm")
+
+		s.Contains(result, "No virt-launcher pod found")
+		s.Nil(podNames)
+	})
+}
+
+func (s *TroubleshootToolSuite) TestFetchVirtLauncherPodLogs() {
+	s.Run("returns message when no pod names", func() {
+		result := fetchVirtLauncherPodLogs(context.Background(), nil, "test-ns", nil)
+		s.Contains(result, "## virt-launcher Pod Logs")
+		s.Contains(result, "No pod found")
+	})
+
+	s.Run("returns message when empty pod names", func() {
+		result := fetchVirtLauncherPodLogs(context.Background(), nil, "test-ns", []string{})
+		s.Contains(result, "No pod found")
+	})
+}
+
+func TestTroubleshootToolSuite(t *testing.T) {
+	suite.Run(t, new(TroubleshootToolSuite))
+}


### PR DESCRIPTION
## Summary

- Adds `vm_troubleshoot` as a proper MCP **Tool** (in addition to the existing `vm-troubleshoot` Prompt)
- Enriches the diagnostic report with **DataVolume/PVC status** and **cloud-init configuration** extraction
- Includes comprehensive unit tests (25 test cases)
- Improves tool description for better LLM tool selection/filtering

## Motivation

The existing `vm-troubleshoot` is registered only as an MCP Prompt. MCP Prompts are user-facing templates that must be explicitly selected — LLMs cannot autonomously call them during conversations. When a user asks OLS "why is my VM not starting?", the LLM has no way to invoke the troubleshooting logic unless the user manually selects the prompt.

By exposing the same diagnostic functionality as a Tool, the LLM can proactively gather VM diagnostic data when it determines troubleshooting is needed, enabling a much better user experience.

## Testing Results (OLS + Troubleshooting Mode)

Tested against 3 broken VM scenarios with the kubevirt toolset enabled:

| Model | Scenario | Root Cause Found |
|-------|----------|-----------------|
| gpt-5.2 | VM stuck Provisioning (missing StorageClass) | Yes — identified `premium-nvme-storage` doesn't exist |
| gpt-5.2 | VM crashloop (cloud-init `shutdown -h now`) | Yes — found the `runcmd` entry |
| gpt-5.2 | Migration failure (nodeSelector pinning) | Yes — identified hostname nodeSelector |
| gpt-4o-mini | Same scenarios (with explicit tool hint) | 2/3 (missed cloud-init) |

The DataVolume/PVC and cloud-init enrichment directly addresses the gpt-4o-mini gap — the data is now in the report without needing separate tool calls.

## Changes

| File | Change |
|------|--------|
| `pkg/toolsets/kubevirt/vm/troubleshoot/tool.go` | New tool + DataVolume/PVC status + cloud-init extraction |
| `pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go` | 25 unit tests covering all helpers |
| `pkg/toolsets/kubevirt/toolset.go` | Register the new tool in `GetTools()` |
| `pkg/mcp/testdata/toolsets-kubevirt-tools.json` | Updated snapshot with new description |

## Diagnostic Report Sections

The tool returns a structured markdown report with:
1. **VirtualMachine Status** — conditions, printableStatus
2. **VirtualMachineInstance Status** — phase, nodeName, conditions
3. **Volumes** — configured disk volumes
4. **DataVolume/PVC Status** — binding state, StorageClass, CDI errors
5. **Cloud-Init Configuration** — userData/networkData content
6. **virt-launcher Pod** — pod state and container status
7. **Pod Logs** — last 50 lines from compute container
8. **Events** — VM/VMI related events

## Backward Compatibility

The existing `vm-troubleshoot` Prompt is preserved unchanged for clients that use the MCP prompts interface.

## Test plan

- [x] Unit tests for tool registration, schema, and annotations
- [x] Unit tests for all helper functions (fetchVMStatus, fetchVMIStatus, fetchVolumes, fetchVirtLauncherPod, fetchVirtLauncherPodLogs, fetchDataVolumeStatus, extractCloudInit)
- [x] Verified OLS in `mode: troubleshooting` proactively invokes the tool when asked about VM issues
- [x] Tested with gpt-5.2 and gpt-4o-mini against real broken VM scenarios
- [ ] CI integration tests (envtest)