### PR TITLE
NO-JIRA: adjust merge strategy to deal with autogenerated content collisions

### DIFF
--- a/build/openshift/sync-upstream.mk
+++ b/build/openshift/sync-upstream.mk
@@ -1,4 +1,9 @@
 ##@ Upstream Sync
+# Limitation: -X theirs silently resolves textual conflicts in favor of upstream.
+# Downstream-specific patches to shared code (same lines as upstream) will be
+# dropped without warning. Only structural conflicts (delete/modify, rename)
+# trigger a hard failure. If downstream carries patches to files upstream also
+# edits, verify the merge result before approving the sync PR.
 
 UPSTREAM_REPO ?= containers/kubernetes-mcp-server
 UPSTREAM_REMOTE ?= upstream
@@ -41,11 +46,33 @@ sync-upstream-pr: ## Create/update PR to sync with upstream (requires gh CLI)
 	echo "  Behind by $$BEHIND_COUNT commits"; \
 	git checkout -B $(SYNC_BRANCH_NAME) $(ORIGIN_REMOTE)/main
 	@echo "🔀 Merging upstream changes..."
-	@git merge --no-ff $(UPSTREAM_REMOTE)/main -m "chore: merge upstream changes"
+	@if ! git merge --no-ff -X theirs $(UPSTREAM_REMOTE)/main -m "chore: merge upstream changes"; then \
+		echo "⚠️  Merge conflicts remain after -X theirs. Attempting to resolve generated files..."; \
+		CONFLICTED=$$(git diff --name-only --diff-filter=U); \
+		UNRESOLVABLE=""; \
+		for f in $$CONFLICTED; do \
+			case "$$f" in \
+				go.sum|go.mod|vendor/*) \
+					echo "  Accepting upstream for generated file: $$f"; \
+					git checkout --theirs "$$f"; \
+					git add "$$f"; \
+					;; \
+				*) \
+					UNRESOLVABLE="$$UNRESOLVABLE $$f"; \
+					;; \
+			esac; \
+		done; \
+		if [ -n "$$UNRESOLVABLE" ]; then \
+			echo "❌ Unresolvable conflicts in:$$UNRESOLVABLE"; \
+			git merge --abort; \
+			exit 1; \
+		fi; \
+		git commit --no-edit; \
+	fi
 	@echo "🔧 Updating dependencies..."
 	@go mod tidy && go mod vendor
 	@if [ -n "$$(git status --porcelain go.mod go.sum vendor/)" ]; then \
-		echo "📦 Changes detected. Committing and pushing..."; \
+		echo "📦 Changes detected in generated files. Committing..."; \
 		git add go.mod go.sum vendor/; \
 		git commit -m "chore: update dependencies and vendor"; \
 	fi


### PR DESCRIPTION
Even though the existing makefile handled re-generation of generated content (go.*), we failed during the merge because we didn't specify a strategy that would work in headless mode.  
Added that, plus some diagnostics which would break loudly if/when we get to an untenable collision. 
There is a gap where up/downstream commits change the same lines in the same files at the same time, when we'll silently drop the downstream content.  
In theory this is fine because upstream is the source of truth, and we can add that capacity in the future if needed. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upstream sync handling to automatically resolve simple merge conflicts where possible.
  * Better detects unresolved conflicts and stops the process with a clear failure instead of leaving partial results.
  * Dependency update checks now focus on generated dependency files, with updated user-facing messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->