### PR TITLE
NO-JIRA: fix(sync): wait for GitHub to index branch before creating PR

### DIFF
--- a/build/openshift/sync-upstream.mk
+++ b/build/openshift/sync-upstream.mk
@@ -50,7 +50,20 @@ sync-upstream-pr: ## Create/update PR to sync with upstream (requires gh CLI)
 		git commit -m "chore: update dependencies and vendor"; \
 	fi
 	@echo "📤 Pushing sync branch..."
-	@git push -f $(ORIGIN_REMOTE) $(SYNC_BRANCH_NAME)
+	@PUSHED_SHA=$$(git rev-parse $(SYNC_BRANCH_NAME)); \
+	git push -f $(ORIGIN_REMOTE) $(SYNC_BRANCH_NAME); \
+	echo "⏳ Waiting for GitHub to index pushed branch at $$PUSHED_SHA..."; \
+	OWNER_REPO=$$(gh repo view --json nameWithOwner -q .nameWithOwner); \
+	for i in $$(seq 1 12); do \
+		INDEXED=$$(gh api "repos/$$OWNER_REPO/git/refs/heads/$(SYNC_BRANCH_NAME)" \
+			--jq '.object.sha' 2>/dev/null || echo ""); \
+		if [ "$$INDEXED" = "$$PUSHED_SHA" ]; then \
+			echo "✅ Branch indexed."; \
+			break; \
+		fi; \
+		echo "  (attempt $$i/12: waiting for index, retrying in 5s...)"; \
+		sleep 5; \
+	done
 	@echo "🚀 Creating or updating PR..."
 	@CHANGELOG=$$(git log --pretty=format:"- %h %s (%an)" $(ORIGIN_REMOTE)/main..$(UPSTREAM_REMOTE)/main); \
 	BEHIND_COUNT=$$(git rev-list --count $(ORIGIN_REMOTE)/main..$(UPSTREAM_REMOTE)/main); \


### PR DESCRIPTION
gh pr create fails with "Head sha can't be blank / No commits between main and upstream-sync" when called immediately after git push -f, because GitHub's refs API hasn't yet propagated the newly-pushed SHA.

Poll the git/refs API until the indexed SHA matches the pushed SHA before attempting PR creation, eliminating the race condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the upstream sync process to wait for GitHub to recognize the pushed branch before creating or updating a pull request, reducing intermittent sync failures.
  * Added retry-based checks after force-pushing the sync branch to make PR creation more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->