### PR TITLE
NO-JIRA: Fix Tekton pipeline namespace mismatch error

### DIFF
--- a/.tekton/openshift-mcp-server-main-pull-request.yaml
+++ b/.tekton/openshift-mcp-server-main-pull-request.yaml
@@ -10,12 +10,12 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
+    pipelinesascode.tekton.dev/target-namespace: "ocp-mcp-server-tenant"
   labels:
     appstudio.openshift.io/application: mcp-server-main
     appstudio.openshift.io/component: openshift-mcp-server-main
     pipelines.appstudio.openshift.io/type: build
   name: openshift-mcp-server-main-on-pull-request
-  namespace: ocp-mcp-server-tenant
 spec:
   params:
   - name: git-url

--- a/.tekton/openshift-mcp-server-main-push.yaml
+++ b/.tekton/openshift-mcp-server-main-push.yaml
@@ -9,12 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
+    pipelinesascode.tekton.dev/target-namespace: "ocp-mcp-server-tenant"
   labels:
     appstudio.openshift.io/application: mcp-server-main
     appstudio.openshift.io/component: openshift-mcp-server-main
     pipelines.appstudio.openshift.io/type: build
   name: openshift-mcp-server-main-on-push
-  namespace: ocp-mcp-server-tenant
 spec:
   params:
   - name: git-url


### PR DESCRIPTION
Remove hardcoded namespace from PipelineRun metadata and add target-namespace annotation. This fixes the "namespace of the provided object does not match the namespace sent on the request" error from Tekton Controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pipeline configuration to use the supported target-namespace setting.
  * Pipeline runs now target the intended tenant namespace more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->