### PR TITLE
NO-JIRA: switch PR update API

### DIFF
--- a/build/openshift/sync-upstream.mk
+++ b/build/openshift/sync-upstream.mk
@@ -99,9 +99,15 @@ sync-upstream-pr: ## Create/update PR to sync with upstream (requires gh CLI)
 	@echo "  OWNER_REPO='$(OWNER_REPO)'"; \
 	CHANGELOG=$$(git log --pretty=format:"- %h %s (%an)" $(ORIGIN_REMOTE)/main..$(UPSTREAM_REMOTE)/main); \
 	BEHIND_COUNT=$$(git rev-list --count $(ORIGIN_REMOTE)/main..$(UPSTREAM_REMOTE)/main); \
-	if gh pr list --repo "$(OWNER_REPO)" --head $(SYNC_BRANCH_NAME) --state open | grep -q "$(SYNC_BRANCH_NAME)"; then \
-		echo "  Updating existing PR..."; \
-		gh pr edit $(SYNC_BRANCH_NAME) --repo "$(OWNER_REPO)" --body "### 🔄 Upstream Sync"$$'\n'$$'\n'"**Update:** $$(date)"$$'\n'$$'\n'"New changes detected from upstream:"$$'\n'"$$CHANGELOG"; \
+	if ! PR_NUMBER=$$(gh pr list --repo "$(OWNER_REPO)" --head $(SYNC_BRANCH_NAME) --state open --json number --jq '.[0].number'); then \
+		echo "❌ Failed to list PRs (possible rate-limit or auth error). Aborting to prevent duplicate PR creation."; \
+		exit 1; \
+	fi; \
+	if [ -n "$$PR_NUMBER" ] && [ "$$PR_NUMBER" != "null" ]; then \
+		echo "  Updating existing PR #$$PR_NUMBER..."; \
+		PR_BODY="### 🔄 Upstream Sync"$$'\n'$$'\n'"**Update:** $$(date)"$$'\n'$$'\n'"New changes detected from upstream:"$$'\n'"$$CHANGELOG"; \
+		gh api --method PATCH "repos/$(OWNER_REPO)/pulls/$$PR_NUMBER" \
+			--raw-field body="$$PR_BODY"; \
 	else \
 		echo "  Creating new PR..."; \
 		gh pr create \


### PR DESCRIPTION
'Update existing PR' approach was using a deprecated github API (via the `gh` tool) which was [failing](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/80316/rehearse-80316-periodic-openshift-mcp-server-upstream-pr-sync/2075581184070389760). 

I thought it would be nice to validate this logic path while we have the current conflict rather than wait for another time.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of existing upstream synchronization pull requests.
  * Updated pull request descriptions more reliably when an existing request is found.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->