### PR TITLE
NO-JIRA: disable github action renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,9 @@
   "gomod": {
     "enabled": false
   },
+  "github-actions": {
+    "enabled": false
+  },
   "vulnerabilityAlerts": {
     "enabled": true
   }


### PR DESCRIPTION
github actions are disabled in this repo, so there's no point in having renovatebot evaluating them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings to exclude GitHub Actions from processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->