### PR TITLE
NO-JIRA: add NO-JIRA title to sync PRs; remove commit count from title

### DIFF
--- a/build/openshift/sync-upstream.mk
+++ b/build/openshift/sync-upstream.mk
@@ -112,7 +112,7 @@ sync-upstream-pr: ## Create/update PR to sync with upstream (requires gh CLI)
 		echo "  Creating new PR..."; \
 		gh pr create \
 			--repo "$(OWNER_REPO)" \
-			--title "chore: sync with upstream $$(date +'%Y-%m-%d') - $$BEHIND_COUNT new commits" \
+			--title "NO-JIRA: sync with upstream $$(date +'%Y-%m-%d')" \
 			--body "### 🔄 Upstream Sync"$$'\n'$$'\n'"This PR syncs the fork with the latest upstream changes."$$'\n'$$'\n'"**Changes:**"$$'\n'"$$CHANGELOG" \
 			--base main \
 			--head $(SYNC_BRANCH_NAME); \


### PR DESCRIPTION
Adds 'NO-JIRA' prefix to sync PR titles so that they can be quickly merged w/o a retitle.
Removes the commit count from the title.  As nice as this appears, it's more difficult to update for long-lived PRs and the PR body clearly lists the commits anyway, so it's of little actual value. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the title format for upstream synchronization pull requests.
  * Titles now use a fixed `NO-JIRA:` prefix and the current date for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->