### PR TITLE
NO-JIRA: chore: disable renovate updates for python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,12 @@
   "gomod": {
     "enabled": false
   },
+  "pip_requirements": {
+    "enabled": false
+  },
+  "pep621": {
+    "enabled": false
+  },
   "github-actions": {
     "enabled": false
   },


### PR DESCRIPTION
Like other deps, these should be updated upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to exclude Python dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->