### PR TITLE
NO-JIRA: Enable multi-architecture hermetic builds in the Konflux main pipeline

### DIFF
--- a/.tekton/openshift-mcp-server-main-pull-request.yaml
+++ b/.tekton/openshift-mcp-server-main-pull-request.yaml
@@ -29,6 +29,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ocp
   pipelineSpec:
@@ -62,7 +65,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -75,7 +78,7 @@ spec:
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -384,6 +387,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift-mcp-server-{{target_branch}} --report --org=a76c0ad2-d811-40ce-b935-681679e2932d"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/openshift-mcp-server-main-push.yaml
+++ b/.tekton/openshift-mcp-server-main-push.yaml
@@ -26,6 +26,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ocp
   pipelineSpec:
@@ -59,7 +62,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -72,7 +75,7 @@ spec:
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -381,6 +384,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift-mcp-server-{{target_branch}} --report --org=a76c0ad2-d811-40ce-b935-681679e2932d"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary

This PR updates the Konflux main pipeline to support multi-architecture builds while enabling hermetic builds.

## Changes

- Enable multi-architecture builds in the Konflux main pipeline
- Enable hermetic build execution
- Align the main pipeline with the latest Konflux build requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Compatibility**
  - Builds now include Linux ARM64, PPC64LE, and s390x platforms alongside x86_64.
  - Source image creation is enabled by default for pull request and push builds.

- **Quality Checks**
  - Optional checks are skipped by default unless explicitly enabled.
  - Security scan results now include project-specific reporting and organization details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->