### PR TITLE
NO-JIRA: Move OpenShift-specific toolset blank imports into openshift_modules.go.

### DIFF
--- a/pkg/mcp/modules.go
+++ b/pkg/mcp/modules.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/cluster-diagnostics"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/config"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/core"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/helm"
@@ -10,5 +9,4 @@ import (
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/netobserv"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/tekton"
-	_ "github.com/rhobs/obs-mcp/pkg/toolset"
 )

--- a/pkg/mcp/openshift_modules.go
+++ b/pkg/mcp/openshift_modules.go
@@ -1,0 +1,10 @@
+package mcp
+
+import (
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/cluster-diagnostics"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/mustgather"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/netedge"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/oadp"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/openshift"
+	_ "github.com/rhobs/obs-mcp/pkg/toolset"
+)


### PR DESCRIPTION
Keeps modules.go limited to shared upstream toolsets and isolates downstream registrations in a separate file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenShift-focused operational tools, including diagnostics, networking, backup and recovery, and must-gather workflows.
  - Expanded the available observability capabilities within the OpenShift environment.

- **Bug Fixes**
  - Improved tool availability and startup registration so supported OpenShift capabilities are consistently accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->