### PR TITLE
RHOBS-1641: docs: rename useRoute to use_route in observability guides and add new eval

### DIFF
--- a/docs/observability/logs.md
+++ b/docs/observability/logs.md
@@ -122,7 +122,7 @@ insecure = false
 
 # Resolve Loki query URLs via OpenShift Routes instead of in-cluster Services.
 # Default: false
-useRoute = false
+use_route = false
 ```
 
 ### Configuration reference
@@ -132,7 +132,7 @@ useRoute = false
 | `auth_mode` | string | `"header"` | Bearer token source: `"header"` or `"kubeconfig"` |
 | `loki_url` | string | — | Loki API endpoint URL (optional; use LokiStack discovery if unset) |
 | `insecure` | bool | `false` | Skip TLS certificate verification |
-| `useRoute` | bool | `false` | Use OpenShift `Route` resources for LokiStack gateway URLs |
+| `use_route` | bool | `false` | Use OpenShift `Route` resources for LokiStack gateway URLs |
 
 ---
 
@@ -154,7 +154,7 @@ In `header` mode, you can either set `loki_url` **or** use LokiStack discovery (
 
 ## Instance discovery
 
-The server lists **`LokiStack`** objects cluster-wide and derives gateway base URLs from each resource. With **`useRoute = true`**, it prefers OpenShift `Route` hosts where available.
+The server lists **`LokiStack`** objects cluster-wide and derives gateway base URLs from each resource. With **`use_route = true`**, it prefers OpenShift `Route` hosts where available.
 
 Chosen instances are **validated** against this discovery list before any request is sent, so callers cannot point tools at arbitrary URLs.
 
@@ -163,7 +163,7 @@ Chosen instances are **validated** against this discovery list before any reques
 ## Prerequisites
 
 - **Loki Operator** workloads in the cluster (`LokiStack` CRs) or a standalone Loki endpoint.
-- **RBAC** on the MCP identity to **list** `LokiStack` objects cluster-wide. If **`useRoute`** is enabled, the server also **gets** `Route` resources in each Loki namespace to resolve external hosts.
+- **RBAC** on the MCP identity to **list** `LokiStack` objects cluster-wide. If **`use_route`** is enabled, the server also **gets** `Route` resources in each Loki namespace to resolve external hosts.
 - **Bearer token** with permission to reach the resolved Loki API (same patterns as the metrics toolset).
 
 ---

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -126,7 +126,7 @@ insecure = false
 
 # Resolve Tempo query URLs via OpenShift Routes instead of in-cluster Services.
 # Default: false
-useRoute = false
+use_route = false
 ```
 
 ### Configuration reference
@@ -135,7 +135,7 @@ useRoute = false
 |--------|------|---------|-------------|
 | `auth_mode` | string | `"header"` | Bearer token source: `"header"` or `"kubeconfig"` |
 | `insecure` | bool | `false` | Skip TLS certificate verification |
-| `useRoute` | bool | `false` | Use OpenShift `Route` resources for Tempo gateway/query URLs |
+| `use_route` | bool | `false` | Use OpenShift `Route` resources for Tempo gateway/query URLs |
 
 ---
 
@@ -147,7 +147,7 @@ Bearer token behavior matches the [metrics toolset](./metrics.md) (**Authenticat
 
 ## Instance discovery
 
-The server lists **`TempoStack`** and **`TempoMonolithic`** objects cluster-wide and derives query-frontend or gateway base URLs from each resource. With **`useRoute = true`**, it prefers OpenShift `Route` hosts where available.
+The server lists **`TempoStack`** and **`TempoMonolithic`** objects cluster-wide and derives query-frontend or gateway base URLs from each resource. With **`use_route = true`**, it prefers OpenShift `Route` hosts where available.
 
 Chosen instances are **validated** against this discovery list before any request is sent, so callers cannot point tools at arbitrary URLs.
 
@@ -156,7 +156,7 @@ Chosen instances are **validated** against this discovery list before any reques
 ## Prerequisites
 
 - **Tempo Operator** workloads in the cluster (`TempoStack` and/or `TempoMonolithic` CRs).
-- **RBAC** on the MCP identity to **list** `TempoStack` and `TempoMonolithic` objects cluster-wide. If **`useRoute`** is enabled, the server also **gets** `Route` resources in each Tempo namespace to resolve external hosts.
+- **RBAC** on the MCP identity to **list** `TempoStack` and `TempoMonolithic` objects cluster-wide. If **`use_route`** is enabled, the server also **gets** `Route` resources in each Tempo namespace to resolve external hosts.
 - **Bearer token** with permission to reach the resolved Tempo query API (same patterns as the metrics toolset).
 
 ---

--- a/evals/tasks/observability/traces/search-semconv.yaml
+++ b/evals/tasks/observability/traces/search-semconv.yaml
@@ -1,0 +1,26 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: search-semconv
+  difficulty: medium
+  parallel: true
+  runs: 1
+  labels:
+    category: traces
+    suite: observability
+    toolType: query
+  description: |
+    Tests if the agent can search for traces filtered by a Kubernetes
+    deployment name using the resource.k8s.deployment.name OpenTelemetry
+    semantic convention attribute.
+spec:
+  prompt:
+    inline: |
+      Show traces of the k6-tracing deployment. Use instance tempo1. Include the query you used.
+  verify:
+    - llmJudge:
+        contains: "resource.k8s.deployment.name"
+        reason: "Verify the agent used the resource.k8s.deployment.name attribute to filter traces by Kubernetes deployment"
+    - llmJudge:
+        contains: "k6-tracing"
+        reason: "Verify the agent filtered for the k6-tracing deployment"


### PR DESCRIPTION
Align traces and logs docs with obs-mcp v0.6.0 TOML config key rename.
Adds the new eval added in v0.6.0 as well

cc: @andreasgerstmayr @Cali0707 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated observability logging documentation to consistently use the `use_route` configuration key, including examples, reference details, and prerequisites/RBAC guidance.
  * Updated observability tracing documentation to use `use_route` instead of `useRoute`, keeping configuration examples and descriptive text aligned.
* **Tests**
  * Added a new MCPChecker task to validate trace-search results for `k6-tracing`, including required semantic convention content and query presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->