### PR TITLE
RHOBS-1642: Document obs-mcp observability toolsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ The following sets of tools are available (toolsets marked with ✓ in the Defau
 
 <!-- AVAILABLE-TOOLSETS-START -->
 
-| Toolset   | Description                                                                                                                                                                                                                             | Default |
-|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| Toolset               | Description                                                                                                                                                                                                                             | Default |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | config    | View and manage the current local Kubernetes configuration (kubeconfig)                                                                                                                                                                 | ✓       |
 | core      | Most common tools for Kubernetes management (Pods, Generic Resources, Events, etc.)                                                                                                                                                     | ✓       |
 | helm      | Tools for managing Helm charts and releases                                                                                                                                                                                             |         |
@@ -293,6 +293,10 @@ The following sets of tools are available (toolsets marked with ✓ in the Defau
 | kiali     | Most common tools for managing Kiali, check the [Kiali documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/KIALI.md) for more details.                                                                    |         |
 | kubevirt  | KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details.                                                         |         |
 | netobserv | Network observability tools backed by the NetObserv console plugin API (flows, metrics, export). Check the [NetObserv documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/NETOBSERV.md) for more details. |         |
+| observability/logs    | Toolset for querying Loki logs                                                                                                                                                                                                          |         |
+| observability/metrics | Toolset for querying Prometheus and Alertmanager endpoints in efficient ways.                                                                                                                                                           |         |
+| observability/otelcol | Toolset for OpenTelemetry Collector configuration assistance including schema validation, component documentation, and version management.                                                                                              |         |
+| observability/traces  | Distributed tracing tools for discovering Tempo instances, searching and retrieving traces, and exploring trace attributes.                                                                                                             |         |
 | tekton    | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, and TaskRuns.                                                                                                                                                      |         |
 
 <!-- AVAILABLE-TOOLSETS-END -->
@@ -695,6 +699,356 @@ Examples:
   - `recordType` (`string`) - Flow record type filter.
   - `startTime` (`integer`) - Start of time range as Unix epoch seconds. Overrides timeRange when set.
   - `timeRange` (`integer`) - Lookback window in seconds when startTime is omitted. Default 300.
+
+</details>
+
+<details>
+
+<summary>observability/logs</summary>
+
+- **loki_list_instances** - List LokiStack instances available in the Kubernetes cluster.
+Call this first when using Loki Operator managed stacks so you can pass lokiNamespace and lokiName to other Loki tools.
+
+- **loki_label_names** - List available Loki label names for a time range. Use this before writing LogQL queries.
+  - `end` (`string`) - End time as RFC3339, Unix timestamp, NOW, or NOW-relative expression (optional).
+  - `lokiName` (`string`) - Name of the LokiStack. Use loki_list_instances to discover valid values.
+  - `lokiNamespace` (`string`) - Kubernetes namespace of the LokiStack. Use loki_list_instances to discover valid values.
+  - `start` (`string`) - Start time as RFC3339, Unix timestamp, NOW, or NOW-relative expression (optional).
+  - `tenant` (`string`) - Loki tenant ID (X-Scope-OrgID). For LokiStack gateway modes (e.g. openshift-network) this selects the `/api/logs/v1/<tenant>` path; use `network` for openshift-network.
+
+- **loki_label_values** - List possible values for a Loki label key. Use this to build precise label matchers in LogQL.
+  - `end` (`string`) - End time as RFC3339, Unix timestamp, NOW, or NOW-relative expression (optional).
+  - `label` (`string`) **(required)** - Label key to inspect (for example namespace, pod, container).
+  - `lokiName` (`string`) - Name of the LokiStack. Use loki_list_instances to discover valid values.
+  - `lokiNamespace` (`string`) - Kubernetes namespace of the LokiStack. Use loki_list_instances to discover valid values.
+  - `start` (`string`) - Start time as RFC3339, Unix timestamp, NOW, or NOW-relative expression (optional).
+  - `tenant` (`string`) - Loki tenant ID (X-Scope-OrgID). For LokiStack gateway modes (e.g. openshift-network) this selects the `/api/logs/v1/<tenant>` path; use `network` for openshift-network.
+
+- **loki_query_range** - Execute a Loki LogQL range query and return matching log streams and lines.
+
+Use precise label matchers and a short time window first.
+  - `direction` (`string`) - Search direction: backward (default) or forward.
+  - `duration` (`string`) - Lookback duration from now when start/end are omitted (for example 5m, 1h). Defaults to 15m.
+  - `end` (`string`) - End time as RFC3339, Unix timestamp, NOW, or NOW-relative expression (optional).
+  - `limit` (`integer`) - Maximum number of log lines to return. Defaults to 100, max 1000.
+  - `lokiName` (`string`) - Name of the LokiStack. Use loki_list_instances to discover valid values.
+  - `lokiNamespace` (`string`) - Kubernetes namespace of the LokiStack. Use loki_list_instances to discover valid values.
+  - `query` (`string`) **(required)** - LogQL query string.
+  - `start` (`string`) - Start time as RFC3339, Unix timestamp, NOW, or NOW-relative expression (optional).
+  - `tenant` (`string`) - Loki tenant ID (X-Scope-OrgID). For LokiStack gateway modes (e.g. openshift-network) this selects the `/api/logs/v1/<tenant>` path; use `network` for openshift-network.
+
+</details>
+
+<details>
+
+<summary>observability/metrics</summary>
+
+- **list_metrics** - MANDATORY FIRST STEP: List all available metric names in Prometheus.
+
+YOU MUST CALL THIS TOOL BEFORE ANY OTHER QUERY TOOL
+
+This tool MUST be called first for EVERY observability question to:
+1. Discover what metrics actually exist in this environment
+2. Find the EXACT metric name to use in queries
+3. Avoid querying non-existent metrics
+4. The 'name_regex' parameter should always be provided, and be a best guess of what the metric would be named like.
+5. Do not use a blanket regex like .* or .+ in the 'name_regex' parameter. Use specific ones like kube.*, node.*, etc.
+
+REGEX PATTERN GUIDANCE:
+- Prometheus metrics are typically prefixed (e.g., 'prometheus_tsdb_head_series', 'kube_pod_status_phase')
+- To match metrics CONTAINING a substring, use wildcards: '.*tsdb.*' matches 'prometheus_tsdb_head_series'
+- Without wildcards, the pattern matches EXACTLY: 'tsdb' only matches a metric literally named 'tsdb' (which rarely exists)
+- Common patterns: 'kube_pod.*' (pods), '.*memory.*' (memory-related), 'node_.*' (node metrics)
+- If you get empty results, try adding '.*' before/after your search term
+
+NEVER skip this step. NEVER guess metric names. Metric names vary between environments.
+
+After calling this tool:
+1. Search the returned list for relevant metrics
+2. Use the EXACT metric name found in subsequent queries
+3. If no relevant metric exists, inform the user
+  - `name_regex` (`string`) **(required)** - Regex pattern to filter metric names. IMPORTANT: Metric names are typically prefixed (e.g., 'prometheus_tsdb_head_series'). Use wildcards to match substrings: '.*tsdb.*' matches any metric containing 'tsdb', while 'tsdb' only matches the exact string 'tsdb'. Examples: 'http_.*' (starts with http_), '.*memory.*' (contains memory), 'node_.*' (starts with node_). This parameter is required. Don't pass in blanket regex like '.*' or '.+'.
+
+- **execute_instant_query** - Execute a PromQL instant query to get current/point-in-time values.
+
+PREREQUISITE: You MUST call list_metrics first to verify the metric exists
+
+WHEN TO USE:
+- Current state questions: "What is the current error rate?"
+- Point-in-time snapshots: "How many pods are running?"
+- Latest values: "Which pods are in Pending state?"
+
+The 'query' parameter MUST use metric names that were returned by list_metrics.
+  - `query` (`string`) **(required)** - PromQL query string using metric names verified via list_metrics
+  - `time` (`string`) - Evaluation time as RFC3339 or Unix timestamp. Omit or use 'NOW' for current time.
+
+- **execute_range_query** - Execute a PromQL range query to get time-series data over a period.
+
+PREREQUISITE: You MUST call list_metrics first to verify the metric exists
+
+WHEN TO USE:
+- Trends over time: "What was CPU usage over the last hour?"
+- Rate calculations: "How many requests per second?"
+- Historical analysis: "Were there any restarts in the last 5 minutes?"
+
+TIME PARAMETERS:
+- 'duration': Look back from now (e.g., "5m", "1h", "24h")
+- 'step': Data point resolution (e.g., "1m" for 1-hour duration, "5m" for 24-hour duration)
+
+The 'query' parameter MUST use metric names that were returned by list_metrics.
+  - `duration` (`string`) - Duration to look back from now (e.g., '1h', '30m', '1d', '2w') (optional)
+  - `end` (`string`) - End time as RFC3339 or Unix timestamp (optional). Use `NOW` for current time.
+  - `query` (`string`) **(required)** - PromQL query string using metric names verified via list_metrics
+  - `start` (`string`) - Start time as RFC3339 or Unix timestamp (optional)
+  - `step` (`string`) **(required)** - Query resolution step width (e.g., '15s', '1m', '1h'). Choose based on time range: shorter ranges use smaller steps.
+
+- **show_timeseries** - Display the results as an interactive timeseries chart.
+
+This tool works like execute_range_query but renders the results as a visual chart in the UI clients.
+Use it when the user wants to see a graph or visualization of time-series data and to use visuals to provide the answer.
+Use the show_timeseries as the last tool call after all the other Prometheus tool calls where finalized.
+
+TIME PARAMETERS:
+- 'duration': Look back from now (e.g., "5m", "1h", "24h")
+- 'step': Data point resolution (e.g., "1m" for 1-hour duration, "5m" for 24-hour duration)
+- 'title': A descriptive chart title (e.g., "API Error Rate Over Last Hour")
+- 'description': An explanation of the chart's meaning or context (e.g., "Shows the rate of HTTP 5xx errors per second, broken down by pod")
+
+The 'query' parameter MUST be a range query and must use metric names that were returned by list_metrics.
+  - `description` (`string`) - Explanation of the chart's meaning or context (e.g., 'Shows the rate of HTTP 5xx errors per second, broken down by pod'). Displayed below the title when provided.
+  - `duration` (`string`) - Duration to look back from now (e.g., '1h', '30m', '1d', '2w') (optional)
+  - `end` (`string`) - End time as RFC3339 or Unix timestamp (optional). Use `NOW` for current time.
+  - `query` (`string`) **(required)** - PromQL query string using metric names verified via list_metrics
+  - `start` (`string`) - Start time as RFC3339 or Unix timestamp (optional)
+  - `step` (`string`) **(required)** - Query resolution step width (e.g., '15s', '1m', '1h'). Choose based on time range: shorter ranges use smaller steps.
+  - `title` (`string`) - Human-readable chart title describing what the query shows (e.g., 'API Error Rate Over Last Hour'). Displayed above the chart when provided.
+
+- **get_label_names** - Get all label names (dimensions) available for filtering a metric.
+
+WHEN TO USE (after calling list_metrics):
+- To discover how to filter metrics (by namespace, pod, service, etc.)
+- Before constructing label matchers in PromQL queries
+
+The 'metric' parameter should use a metric name from list_metrics output.
+  - `end` (`string`) - End time for label discovery as RFC3339 or Unix timestamp (optional, defaults to now)
+  - `metric` (`string`) - Metric name (from list_metrics) to get label names for. Leave empty for all metrics.
+  - `start` (`string`) - Start time for label discovery as RFC3339 or Unix timestamp (optional, defaults to 1 hour ago)
+
+- **get_label_values** - Get all unique values for a specific label.
+
+WHEN TO USE (after calling list_metrics and get_label_names):
+- To find exact label values for filtering (namespace names, pod names, etc.)
+- To see what values exist before constructing queries
+
+The 'metric' parameter should use a metric name from list_metrics output.
+  - `end` (`string`) - End time for label value discovery as RFC3339 or Unix timestamp (optional, defaults to now)
+  - `label` (`string`) **(required)** - Label name (from get_label_names) to get values for
+  - `metric` (`string`) - Metric name (from list_metrics) to scope the label values to. Leave empty for all metrics.
+  - `start` (`string`) - Start time for label value discovery as RFC3339 or Unix timestamp (optional, defaults to 1 hour ago)
+
+- **get_series** - Get time series matching selectors and preview cardinality.
+
+WHEN TO USE (optional, after calling list_metrics):
+- To verify label filters match expected series before querying
+- To check cardinality and avoid slow queries
+
+CARDINALITY GUIDANCE:
+- <100 series: Safe
+- 100-1000: Usually fine
+- >1000: Add more label filters
+
+The selector should use metric names from list_metrics output.
+  - `end` (`string`) - End time for series discovery as RFC3339 or Unix timestamp (optional, defaults to now)
+  - `matches` (`string`) **(required)** - PromQL series selector using metric names from list_metrics
+  - `start` (`string`) - Start time for series discovery as RFC3339 or Unix timestamp (optional, defaults to 1 hour ago)
+
+- **get_alerts** - Get alerts from Alertmanager.
+
+WHEN TO USE:
+- START HERE when investigating issues: if the user asks about things breaking, errors, failures, outages, services being down, or anything going wrong in the cluster
+- When the user mentions a specific alert name - use this tool to get the alert's full labels (namespace, pod, service, etc.) which are essential for further investigation with other tools
+- To see currently firing alerts in the cluster
+- To check which alerts are active, silenced, or inhibited
+- To understand what's happening before diving into metrics or logs
+
+INVESTIGATION TIP: Alert labels often contain the exact identifiers (pod names, namespaces, job names) needed for targeted queries with prometheus tools.
+
+FILTERING:
+- Use 'active' to filter for only active alerts (not resolved)
+- Use 'silenced' to filter for silenced alerts
+- Use 'inhibited' to filter for inhibited alerts
+- Use 'filter' to apply label matchers (e.g., "alertname=HighCPU")
+- Use 'receiver' to filter alerts by receiver name
+
+All filter parameters are optional. Without filters, all alerts are returned.
+  - `active` (`boolean`) - Filter for active alerts only (true/false, optional)
+  - `filter` (`string`) - Label matchers to filter alerts (e.g., 'alertname=HighCPU', optional)
+  - `inhibited` (`boolean`) - Filter for inhibited alerts only (true/false, optional)
+  - `receiver` (`string`) - Receiver name to filter alerts (optional)
+  - `silenced` (`boolean`) - Filter for silenced alerts only (true/false, optional)
+  - `unprocessed` (`boolean`) - Filter for unprocessed alerts only (true/false, optional)
+
+- **get_silences** - Get silences from Alertmanager.
+
+WHEN TO USE:
+- To see which alerts are currently silenced
+- To check active, pending, or expired silences
+- To investigate why certain alerts are not firing notifications
+
+FILTERING:
+- Use 'filter' to apply label matchers to find specific silences
+
+Silences are used to temporarily mute alerts based on label matchers. This tool helps you understand what is currently silenced in your environment.
+  - `filter` (`string`) - Label matchers to filter silences (e.g., 'alertname=HighCPU', optional)
+
+</details>
+
+<details>
+
+<summary>observability/otelcol</summary>
+
+- **otelcol_list_components** - List available OpenTelemetry Collector components (receivers, processors, exporters, extensions, connectors) for a given version.
+  - `version` (`string`) - Collector version (e.g., 'v0.100.0'). Defaults to latest available.
+
+- **otelcol_get_component_schema** - Get the JSON schema for an OpenTelemetry Collector component's configuration options.
+  - `component_name` (`string`) **(required)** - Component name from otelcol_list_components (e.g., 'otlp', 'batch', 'debug')
+  - `component_type` (`string`) **(required)** - Component type: receiver, processor, exporter, extension, connector
+  - `version` (`string`) - Collector version (e.g., 'v0.100.0'). Defaults to latest available.
+
+- **otelcol_validate_config** - Validate an OpenTelemetry Collector component configuration against its JSON schema.
+  - `component_name` (`string`) **(required)** - Component name from otelcol_list_components (e.g., 'otlp', 'batch', 'debug')
+  - `component_type` (`string`) **(required)** - Component type: receiver, processor, exporter, extension, connector
+  - `config` (`string`) **(required)** - Configuration to validate as YAML or JSON string
+  - `format` (`string`) - Config format: 'yaml' (default) or 'json'
+  - `version` (`string`) - Collector version (e.g., 'v0.100.0'). Defaults to latest available.
+
+- **otelcol_get_versions** - List available OpenTelemetry Collector versions and identify the latest.
+
+</details>
+
+<details>
+
+<summary>observability/traces</summary>
+
+- **tempo_list_instances** - List all Tempo instances available in the Kubernetes cluster.
+Call this tool first to discover available Tempo instances before using other Tempo tools,
+as the returned namespace, name, and tenant values are required parameters for all other Tempo tools.
+Always print the output of this tool in a table.
+
+- **tempo_get_trace_by_id** - Retrieve a single distributed trace by its trace ID from Tempo.
+Returns the full trace with all its spans, including service names, operation names, durations, and attributes.
+Use this tool when you already have a specific trace ID, e.g. from search results or logs.
+  - `end` (`string`) - Optional end of the time range in RFC 3339 format, e.g. "2025-01-02T00:00:00Z".
+Narrows the time range to improve query performance.
+  - `start` (`string`) - Optional start of the time range in RFC 3339 format, e.g. "2025-01-01T00:00:00Z".
+Narrows the time range to improve query performance.
+  - `tempoName` (`string`) **(required)** - The name of the Tempo instance to query. Use tempo_list_instances to discover available instance names.
+  - `tempoNamespace` (`string`) **(required)** - The Kubernetes namespace where the Tempo instance is deployed. Use tempo_list_instances to discover available namespaces.
+  - `tenant` (`string`) - The tenant to query. This parameter is required for multi-tenant instances. Use tempo_list_instances to discover available tenants for each instance.
+  - `traceid` (`string`) **(required)** - The trace ID to retrieve, e.g. "26dad4a0e2b0dd9a440dd5ff203a24a4".
+
+- **tempo_search_traces** - Search for distributed traces in Tempo using TraceQL.
+Use this tool to find traces matching specific criteria such as service name, HTTP status code, duration, or other span or resource attributes.
+
+IMPORTANT — "slow" or "long" trace requests: Do NOT guess a duration threshold.
+First call this tool WITHOUT a duration filter to establish a latency baseline, then use that baseline to set a sensible threshold.
+Both steps are required — do NOT skip the second search with the duration filter.
+Skip this two-step process only when the user provides an explicit duration (e.g. "find traces slower than 2s").
+
+  - `end` (`string`) - End of the time range in RFC 3339 format, e.g. "2025-01-01T00:00:00Z".
+Use "NOW" for current time.
+Both start and end should be provided to search the full time range; if omitted, only a small window of recent data is searched.
+  - `limit` (`integer`) - Maximum number of traces to return. Defaults to the server-side limit if not specified.
+  - `query` (`string`) **(required)** - A TraceQL query expression. Format:
+query: "{ <filters joined by &&> }"
+
+Filters:
+- service name:     resource.service.name="<value>" (string, use quotes)
+- HTTP status code: span.http.response.status_code=<code> (number, no quotes)
+- duration:         duration><value like 100ms, 2s, 5m> (no quotes)
+- error status:     status=error (keyword, NO quotes — do NOT write status="error")
+
+IMPORTANT: status values (error, ok, unset) are keywords, NOT strings. Write status=error, NEVER status="error".
+
+Operators: =, !=, >, <, >=, <=
+
+Common attributes:
+- resource.service.name (service name)
+- resource.k8s.namespace.name (Kubernetes namespace)
+- resource.k8s.deployment.name (Kubernetes deployment)
+- resource.k8s.statefulset.name (Kubernetes statefulset)
+- resource.k8s.daemonset.name (Kubernetes daemonset)
+- resource.k8s.replicaset.name (Kubernetes replicaset)
+- resource.k8s.pod.name (Kubernetes pod)
+- resource.k8s.container.name (Kubernetes container)
+- resource.k8s.job.name (Kubernetes job)
+- resource.k8s.cronjob.name (Kubernetes cronjob)
+- resource.k8s.node.name (Kubernetes node)
+- resource.k8s.cluster.name (Kubernetes cluster)
+- span.http.response.status_code (HTTP response code)
+- span.http.request.method (HTTP method like GET, POST)
+- span.url.full (request URL)
+- name (span name / operation name, e.g. "GET /api/users")
+- duration (trace duration, e.g. 100ms, 2s)
+- status (trace status: ok, error, unset)
+
+Note: older instrumentation may use legacy HTTP attribute names (e.g. span.http.status_code instead of span.http.response.status_code).
+If a query returns no results, try tempo_search_tags to check which attributes exist.
+
+IMPORTANT:
+- Always wrap filters in curly braces { }.
+- Do NOT use SQL, PromQL, or Lucene syntax.
+- Do NOT omit the "resource." or "span." prefix from attribute names
+- When the user refers to a Kubernetes resource type (deployment, pod, namespace, etc.), use the matching resource.k8s.* attribute, NOT resource.service.name.
+
+Examples:
+- { resource.service.name="frontend" }
+- { resource.k8s.deployment.name="checkout" && span.http.response.status_code>=500 }
+- { status=error && duration>2s }
+
+If unsure which attributes to filter on, use tempo_search_tags to discover available attributes before building a query.
+
+  - `spss` (`integer`) - Maximum number of matching spans to return per trace.
+  - `start` (`string`) - Start of the time range in RFC 3339 format, e.g. "2025-01-01T00:00:00Z".
+Use "NOW" for current time.
+Both start and end should be provided to search the full time range; if omitted, only a small window of recent data is searched.
+  - `tempoName` (`string`) **(required)** - The name of the Tempo instance to query. Use tempo_list_instances to discover available instance names.
+  - `tempoNamespace` (`string`) **(required)** - The Kubernetes namespace where the Tempo instance is deployed. Use tempo_list_instances to discover available namespaces.
+  - `tenant` (`string`) - The tenant to query. This parameter is required for multi-tenant instances. Use tempo_list_instances to discover available tenants for each instance.
+
+- **tempo_search_tags** - List available tag names (attribute keys) in Tempo, grouped by scope.
+Use this tool to discover which attributes are available for building TraceQL queries with tempo_search_traces.
+For example, this tool may reveal tag names like "service.name" (in the "resource" scope) or "http.response.status_code" (in the "span" scope).
+To use these in TraceQL queries, prefix them with their scope, e.g. "resource.service.name" or "span.http.response.status_code".
+  - `end` (`string`) - Optional end of the time range (in RFC 3339 format, e.g. "2025-01-01T00:00:00Z") to filter which traces are considered when listing tags.
+  - `limit` (`integer`) - Maximum number of tag names to return per scope.
+  - `maxStaleValues` (`integer`) - Maximum number of consecutive blocks without new tag names before the search stops early. Higher values are more thorough but slower.
+  - `query` (`string`) - Optional TraceQL query to filter which traces are considered when listing tags,
+e.g. '{ resource.service.name="payment-service" }' to only show tags present in traces from the 'payment-service' service.
+  - `scope` (`string`) - Filter tags to a specific scope. One of:
+"resource" (service-level attributes like service.name),
+"span" (individual span attributes like http.response.status_code),
+"intrinsic" (built-in fields like duration, status, name).
+If omitted, tags from all scopes are returned.
+  - `start` (`string`) - Optional start of the time range (in RFC 3339 format, e.g. "2025-01-01T00:00:00Z") to filter which traces are considered when listing tags.
+  - `tempoName` (`string`) **(required)** - The name of the Tempo instance to query. Use tempo_list_instances to discover available instance names.
+  - `tempoNamespace` (`string`) **(required)** - The Kubernetes namespace where the Tempo instance is deployed. Use tempo_list_instances to discover available namespaces.
+  - `tenant` (`string`) - The tenant to query. This parameter is required for multi-tenant instances. Use tempo_list_instances to discover available tenants for each instance.
+
+- **tempo_search_tag_values** - List the known values for a specific tag (attribute key) in Tempo.
+Use this tool to discover what values exist for a given tag, e.g. to find all service names (values of "resource.service.name") or all HTTP methods (values of "span.http.request.method").
+This is useful for building accurate TraceQL queries with tempo_search_traces.
+  - `end` (`string`) - Optional end of the time range (in RFC 3339 format, e.g. "2025-01-01T00:00:00Z") to filter which traces are considered when listing values.
+  - `limit` (`integer`) - Maximum number of tag values to return.
+  - `maxStaleValues` (`integer`) - Maximum number of consecutive blocks without new values before the search stops early. Higher values are more thorough but slower.
+  - `query` (`string`) - Optional TraceQL query to filter which traces are considered when listing values,
+e.g. '{ resource.service.name="payment-service" }' to only show tag values from the 'payment-service' service.
+  - `start` (`string`) - Optional start of the time range (in RFC 3339 format, e.g. "2025-01-01T00:00:00Z") to filter which traces are considered when listing values.
+  - `tag` (`string`) **(required)** - The fully qualified tag name to get values for, including its scope prefix, e.g. "resource.service.name" or "span.http.response.status_code".
+Use tempo_search_tags to discover available tag names.
+  - `tempoName` (`string`) **(required)** - The name of the Tempo instance to query. Use tempo_list_instances to discover available instance names.
+  - `tempoNamespace` (`string`) **(required)** - The Kubernetes namespace where the Tempo instance is deployed. Use tempo_list_instances to discover available namespaces.
+  - `tenant` (`string`) - The tenant to query. This parameter is required for multi-tenant instances. Use tempo_list_instances to discover available tenants for each instance.
 
 </details>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,8 +310,8 @@ Toolsets group related tools together. Enable only the toolsets you need to redu
 
 <!-- AVAILABLE-TOOLSETS-START -->
 
-| Toolset   | Description                                                                                                                                                                                                                             | Default |
-|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| Toolset               | Description                                                                                                                                                                                                                             | Default |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | config    | View and manage the current local Kubernetes configuration (kubeconfig)                                                                                                                                                                 | ✓       |
 | core      | Most common tools for Kubernetes management (Pods, Generic Resources, Events, etc.)                                                                                                                                                     | ✓       |
 | helm      | Tools for managing Helm charts and releases                                                                                                                                                                                             |         |
@@ -319,6 +319,10 @@ Toolsets group related tools together. Enable only the toolsets you need to redu
 | kiali     | Most common tools for managing Kiali, check the [Kiali documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/KIALI.md) for more details.                                                                    |         |
 | kubevirt  | KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details.                                                         |         |
 | netobserv | Network observability tools backed by the NetObserv console plugin API (flows, metrics, export). Check the [NetObserv documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/NETOBSERV.md) for more details. |         |
+| observability/logs    | Toolset for querying Loki logs                                                                                                                                                                                                          |         |
+| observability/metrics | Toolset for querying Prometheus and Alertmanager endpoints in efficient ways.                                                                                                                                                           |         |
+| observability/otelcol | Toolset for OpenTelemetry Collector configuration assistance including schema validation, component documentation, and version management.                                                                                              |         |
+| observability/traces  | Distributed tracing tools for discovering Tempo instances, searching and retrieving traces, and exploring trace attributes.                                                                                                             |         |
 | tekton    | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, and TaskRuns.                                                                                                                                                      |         |
 
 <!-- AVAILABLE-TOOLSETS-END -->
@@ -700,6 +704,7 @@ The Helm toolset supports an optional `allowed_registries` allowlist to restrict
 
 Refer to individual toolset documentation for available options:
 - [Kiali Configuration](KIALI.md)
+- [Metrics](observability/metrics.md), [Logs](observability/logs.md), [Tracing](observability/tracing.md), [OpenTelemetry Collector](observability/otelcol.md)
 
 ### Cluster Provider Configuration
 
@@ -812,6 +817,12 @@ traces_sampler_arg = 0.1
 # Toolset-specific configuration
 [toolset_configs.kiali]
 url = "https://kiali.example.com"
+
+# Observability toolsets — see docs/observability/{metrics,logs,tracing,otelcol}.md
+# [toolset_configs."observability/metrics"]
+# [toolset_configs."observability/logs"]
+# [toolset_configs."observability/traces"]
+# [toolset_configs."observability/otelcol"]
 
 [toolset_configs.helm]
 allowed_registries = ["oci://ghcr.io/myorg", "https://charts.example.com"]

--- a/evals/README.md
+++ b/evals/README.md
@@ -16,7 +16,7 @@ evals/
 ├── core-eval-testing/              # Extra agent/provider combinations for core tasks
 ├── results/                        # Committed eval results (baselines)
 └── tasks/                          # Shared task library, grouped by suite (see tasks/README.md)
-    └── <suite>/                    # core, config, helm, kiali, kubevirt, tekton, netobserv
+    └── <suite>/                    # core, config, helm, kiali, kubevirt, tekton, netobserv, observability
         └── <task-name>/
             ├── <task-name>.yaml    # Task definition (prompt, verify, labels). kubevirt/tekton use task.yaml
             ├── setup.sh            # Optional pre-task cluster setup
@@ -26,7 +26,7 @@ evals/
 ```
 
 Tasks are grouped into suites via a `suite: <name>` label. The available suites are
-`core`, `config`, `helm`, `kiali`, `kubevirt`, `tekton`, and `netobserv`.
+`core`, `config`, `helm`, `kiali`, `kubevirt`, `tekton`, `netobserv`, and `observability`.
 
 ## Prerequisites
 

--- a/evals/tasks/README.md
+++ b/evals/tasks/README.md
@@ -11,10 +11,11 @@ This directory hosts the reusable task scenarios that power MCP evaluations for 
 - [KubeVirt tasks](kubevirt/) – virtual machine management workflows that exercise the KubeVirt MCP toolset (VM creation, lifecycle management, resource updates).
 - [Tekton tasks](tekton/) – CI/CD workflows that exercise the Tekton toolset (pipelines, tasks, pipeline runs).
 - [NetObserv tasks](netobserv/) – network flow and metrics workflows that exercise the NetObserv MCP toolset (flows, metrics, export).
+- [Observability tasks](observability/) – metrics, logs, traces, and OpenTelemetry Collector workflows that exercise the `observability/*` MCP toolsets.
 
 ## Anatomy of a Task
 
-Most subdirectories under `core/`, `config/`, `helm/`, `kiali/`, `kubevirt/`, `netobserv/`, or `tekton/` define a single scenario (a few, like `kiali/scripts/`, `kubevirt/helpers/`, and `tekton/helpers/`, hold shared helpers instead):
+Most subdirectories under `core/`, `config/`, `helm/`, `kiali/`, `kubevirt/`, `netobserv/`, `observability/`, or `tekton/` define a single scenario (a few, like `kiali/scripts/`, `kubevirt/helpers/`, and `tekton/helpers/`, hold shared helpers instead):
 
 1. `*.yaml` – declarative description consumed by the evaluation harness (prompts, success criteria, required tools).
 2. `setup.sh` / `verify.sh` / `cleanup.sh` – shell hooks (optional) that prime the cluster, assert post-conditions, and reset resources so tasks stay idempotent.

--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/netobserv"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/tekton"
+	_ "github.com/rhobs/obs-mcp/pkg/toolset"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 


### PR DESCRIPTION
Add observability/* to the Available Toolsets table and Tools section, register obs-mcp in update-readme, and point configuration/evals docs at the observability suite.

cc: @Cali0707 @iNecas 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for observability toolsets covering logs, metrics, distributed tracing, and OpenTelemetry Collector helpers.
  * Expanded usage guidance and parameter references for Loki, Prometheus, Alertmanager, Tempo, and OpenTelemetry tools.
  * Updated configuration examples and reference tables with observability toolset options.
  * Added observability to the documented evaluation suites and task families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->