### PR TITLE
RHOBS-1652: Update observability docs for obs-mcp toolsets

### DIFF
--- a/docs/NETOBSERV.md
+++ b/docs/NETOBSERV.md
@@ -2,7 +2,7 @@
 
 This server exposes tools that call the [NetObserv](https://github.com/netobserv-network-observability/netobserv-operator) console plugin backend API (flows, metrics, export). The toolset targets OpenShift clusters with the NetObserv operator installed; other Kubernetes distributions work when you set `[toolset_configs.netobserv].url` explicitly.
 
-Namespace and workload discovery use the **core** Kubernetes toolset; Prometheus rules and Alertmanager silences belong in **obs-mcp** / **prometheus-mcp-server**, not here.
+Namespace and workload discovery use the **core** Kubernetes toolset; Prometheus queries and Alertmanager silences belong in the **`observability/metrics`** toolset (via [obs-mcp](https://github.com/rhobs/obs-mcp)), not here.
 
 ## Prerequisites
 

--- a/docs/observability/logs.md
+++ b/docs/observability/logs.md
@@ -145,18 +145,17 @@ Bearer token behavior matches the [metrics toolset](./metrics.md) (**Authenticat
 When the `observability/logs` toolset is enabled, the Loki URL is determined in this order:
 
 1. `loki_url` in the `[toolset_configs."observability/logs"]` config section (if set)
-2. `LOKI_URL` environment variable
-3. Default: `http://localhost:3100` (kubeconfig mode only)
+2. Otherwise LokiStack discovery via `lokiNamespace` and `lokiName` on the tool call (use `loki_list_instances` first)
 
-In `header` mode, you can either set `loki_url` **or** use LokiStack discovery (`loki_list_instances` + `lokiNamespace`/`lokiName` arguments on each tool call).
+If neither is provided, the tool returns an error. There is no environment-variable fallback or localhost default when the toolset is embedded in this server.
 
 ---
 
 ## Instance discovery
 
-The server lists **`LokiStack`** objects cluster-wide and derives gateway base URLs from each resource. With **`use_route = true`**, it prefers OpenShift `Route` hosts where available.
+When `loki_url` is not set, the server lists **`LokiStack`** objects cluster-wide and derives gateway base URLs from each resource. With **`use_route = true`**, each instance's URL is resolved via an OpenShift `Route`; if Route resolution fails for any instance, discovery returns an error (there is no fallback to service URLs). Chosen instances are **validated** against this discovery list before any request is sent, so callers cannot point tools at arbitrary URLs.
 
-Chosen instances are **validated** against this discovery list before any request is sent, so callers cannot point tools at arbitrary URLs.
+When `loki_url` is set, that URL is used directly and LokiStack discovery is skipped (`lokiNamespace` / `lokiName` are optional in that case).
 
 ---
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -184,24 +184,28 @@ insecure = false
 # Valid values:
 #   "all"   — enable all guardrails (default)
 #   "none"  — disable all guardrails
-#   or a comma-separated subset:
+#   or a comma-separated list of guardrail names to enable, or !name to disable from "all":
 #     "disallow-explicit-name-label" — reject queries that filter by __name__ label directly
 #     "require-label-matcher"        — reject queries with no label matchers (full table scans)
 #     "disallow-blanket-regex"       — reject .* regexes that would match too many series
+#     "max-metric-cardinality"       — reject queries whose metric exceeds max_metric_cardinality
+#     "!tsdb"                        — disable both TSDB-dependent checks (max-metric-cardinality
+#                                      and disallow-blanket-regex); useful for older Thanos Querier
 # Default: "all"
-guardrails = "none"
+# Example for OpenShift Thanos Querier without TSDB status API:
+# guardrails = "!tsdb"
 
 # Maximum number of series allowed per metric before a query is rejected.
-# Guards against accidentally pulling millions of series.
-# Set to 0 to disable this check.
+# Only applies when the "max-metric-cardinality" guardrail is enabled.
+# Do not set to 0 — use guardrails = "!max-metric-cardinality" (or "none") to disable.
 # Default: 20000
-max_metric_cardinality = 0
+# max_metric_cardinality = 10000
 
 # Maximum number of label values allowed before a blanket regex (.*) is rejected.
 # Only applies when the "disallow-blanket-regex" guardrail is active.
 # Set to 0 to always disallow blanket regex regardless of cardinality.
 # Default: 500
-max_label_cardinality = 0
+# max_label_cardinality = 500
 
 # Controls whether range queries return full data points
 #	instead of summary statistics to the model.
@@ -217,8 +221,8 @@ range_query_full_response = false
 | `prometheus_url` | string | `http://localhost:9090` | Prometheus or Thanos Querier endpoint URL |
 | `alertmanager_url` | string | — | Alertmanager endpoint URL (required for alert/silence tools) |
 | `insecure` | bool | `false` | Skip TLS certificate verification |
-| `guardrails` | string | `"all"` | Query safety checks (`"all"`, `"none"`, or comma-separated list) |
-| `max_metric_cardinality` | uint64 | `20000` | Max series per metric (0 = disabled) |
+| `guardrails` | string | `"all"` | Query safety checks (`"all"`, `"none"`, comma-separated names, or `!name` / `!tsdb` to disable from `"all"`) |
+| `max_metric_cardinality` | uint64 | `20000` | Max series per metric (requires `max-metric-cardinality` guardrail; `0` is not supported) |
 | `max_label_cardinality` | uint64 | `500` | Max label values before blanket regex is rejected (0 = always reject) |
 | `range_query_full_response` | bool | `false` | Controls whether range queries return full data points |
 
@@ -285,10 +289,16 @@ They are enabled by default (`guardrails = "all"`).
 | Disallow explicit name label | `disallow-explicit-name-label` | Rejects queries that filter on `__name__` directly instead of using metric name syntax |
 | Require label matcher | `require-label-matcher` | Rejects bare metric name queries with no label filters (prevents full-cardinality scans) |
 | Disallow blanket regex | `disallow-blanket-regex` | Rejects `.*` or equivalently broad regex matchers when the matched series count exceeds `max_label_cardinality` |
+| Max metric cardinality | `max-metric-cardinality` | Rejects queries whose metric series count exceeds `max_metric_cardinality` (uses TSDB status API) |
 
-To disable a specific guardrail while keeping others:
+Use either a positive list of names to enable, or `!name` to disable selected checks from `"all"`. Do not mix the two styles. The `!tsdb` shortcut disables both TSDB-dependent checks (`max-metric-cardinality` and `disallow-blanket-regex`) when the backend does not expose `/api/v1/status/tsdb` (for example older Thanos Querier).
+
+To disable specific guardrails while keeping others:
 
 ```toml
 [toolset_configs."observability/metrics"]
-guardrails = "disallow-explicit-name-label,require-label-matcher"  # omit disallow-blanket-regex
+# Disable TSDB-dependent checks only:
+guardrails = "!tsdb"
+# Or enable an explicit subset (all others off):
+# guardrails = "disallow-explicit-name-label,require-label-matcher"
 ```

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -121,6 +121,11 @@ Optional settings use a **`[toolset_configs."observability/traces"]`** section (
 # Same semantics as the metrics toolset: "header" (default) or "kubeconfig".
 auth_mode = "kubeconfig"
 
+# URL of the Tempo query API endpoint.
+# Optional — if unset, use TempoStack/TempoMonolithic discovery
+# (tempo_list_instances + tempoNamespace/tempoName on each tool call).
+# tempo_url = "https://tempo-query-frontend.observability.svc.cluster.local:3200"
+
 # Skip TLS verification (development only). Default: false
 insecure = false
 
@@ -134,6 +139,7 @@ use_route = false
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `auth_mode` | string | `"header"` | Bearer token source: `"header"` or `"kubeconfig"` |
+| `tempo_url` | string | — | Tempo API endpoint URL (optional; use Tempo discovery if unset) |
 | `insecure` | bool | `false` | Skip TLS certificate verification |
 | `use_route` | bool | `false` | Use OpenShift `Route` resources for Tempo gateway/query URLs |
 
@@ -147,9 +153,9 @@ Bearer token behavior matches the [metrics toolset](./metrics.md) (**Authenticat
 
 ## Instance discovery
 
-The server lists **`TempoStack`** and **`TempoMonolithic`** objects cluster-wide and derives query-frontend or gateway base URLs from each resource. With **`use_route = true`**, it prefers OpenShift `Route` hosts where available.
+When `tempo_url` is not set, the server lists **`TempoStack`** and **`TempoMonolithic`** objects cluster-wide and derives query-frontend or gateway base URLs from each resource. With **`use_route = true`**, each instance's URL is resolved via an OpenShift `Route`; instances whose Route cannot be resolved are silently skipped (there is no fallback to service URLs). Chosen instances are **validated** against this discovery list before any request is sent, so callers cannot point tools at arbitrary URLs.
 
-Chosen instances are **validated** against this discovery list before any request is sent, so callers cannot point tools at arbitrary URLs.
+When `tempo_url` is set, that URL is used directly and Kubernetes discovery is skipped. Tool calls still require `tempoNamespace` and `tempoName` in the input schema (they are unused for URL resolution in that case).
 
 ---
 

--- a/docs/openshift/user-guide.md
+++ b/docs/openshift/user-guide.md
@@ -102,11 +102,17 @@ toolsets = ["core", "olm", "kubevirt"]
 
 ### Observability
 
-| Tool                     | Description                                                                                                                                                                                                   |
-| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `prometheus_query`       | Executes an instant PromQL query against the cluster's Thanos Querier, returning current metric values at a specified point in time (or the current time if not specified).                                   |
-| `prometheus_query_range` | Executes a range PromQL query against the cluster's Thanos Querier, returning metric values over a time range with a specified resolution step, useful for time-series data, trends, and historical analysis. |
-| `alertmanager_alerts`    | Queries active and pending alerts from the cluster's Alertmanager, with filtering support for active/silenced/inhibited states and Alertmanager filter syntax.                                                |
+Observability query tools are provided by [obs-mcp](https://github.com/rhobs/obs-mcp) toolsets. Enable them explicitly (for example `observability/metrics`). See the [metrics](../observability/metrics.md), [logs](../observability/logs.md), [tracing](../observability/tracing.md), and [otelcol](../observability/otelcol.md) guides for full details.
+
+| Tool                     | Toolset                 | Description                                                                                                                                                                                                   |
+| :----------------------- | :---------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `list_metrics`           | `observability/metrics` | Lists available metric names (regex filter). Call this before writing PromQL queries.                                                                                                                         |
+| `execute_instant_query`  | `observability/metrics` | Executes a PromQL instant query against Prometheus/Thanos Querier, returning current metric values at a point in time.                                                                                        |
+| `execute_range_query`    | `observability/metrics` | Executes a PromQL range query against Prometheus/Thanos Querier, returning time-series data over a window.                                                                                                    |
+| `get_alerts`             | `observability/metrics` | Queries alerts from Alertmanager (requires `alertmanager_url`), with filtering for active/silenced/inhibited states.                                                                                          |
+| `get_silences`           | `observability/metrics` | Queries silences from Alertmanager (requires `alertmanager_url`), with label matcher filtering.                                                                                                               |
+| `loki_query_range`       | `observability/logs`    | Executes a Loki LogQL range query and returns matching log streams and lines.                                                                                                                                 |
+| `tempo_search_traces`    | `observability/traces`  | Searches distributed traces in Tempo using TraceQL.                                                                                                                                                           |
 
 ## Bring Your Own Model
 


### PR DESCRIPTION
Replace leftover in-tree Prometheus/Alertmanager tool names and align metrics/logs/traces guides with obs-mcp v0.6.0 config behavior.

cc: @iNecas @andreasgerstmayr @Cali0707 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified which observability tools handle metrics queries/alerts, silences, logs, and traces, and updated the OpenShift user guide to match.
  * Updated Loki documentation to explain URL resolution rules, required discovery inputs, and error behavior when neither `loki_url` nor discovery parameters are provided.
  * Updated Tempo documentation to document optional `tempo_url`, cluster discovery behavior, and route-based resolution behavior.
  * Refined metrics query guardrails: new `guardrails` defaults, `!name`/`!tsdb` semantics, and updated cardinality constraints and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->