### PR TITLE
NO-JIRA: fix(build): move off base image with failing registry pull

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 ARG BUILDER_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0
-ARG BASE_IMAGE=registry.ci.openshift.org/ocp/5.0:base-rhel9
+ARG BASE_IMAGE=registry.ci.openshift.org/ocp/4.23:base-rhel9
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration build environment to use the supported base image.
  * No changes to application functionality, user workflows, or container startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->