### PR TITLE
NO-JIRA: Revert "Merge pull request #404 from Cali0707/fix-base-image"

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 ARG BUILDER_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0
-ARG BASE_IMAGE=registry.ci.openshift.org/ocp/4.23:base-rhel9
+ARG BASE_IMAGE=registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder


### PR DESCRIPTION
This reverts commit 0c38d2834ada542995215a5e2998a82c98720ec6, reversing changes made to a0a1c370fcce18f76cecdbb2e07d8f4dbafe92dd.

The original change switched our base image while it was unable to pull from the registry.

The hope is to periodically retest this PR until we see our image working again, so that we can go back to the correct image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI build environment to use the OpenShift 5.0 base image.
  * Existing runtime behavior and permissions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->