### PR TITLE
NO-JIRA: chore: run codegen targets after sync

### DIFF
--- a/build/openshift/sync-upstream.mk
+++ b/build/openshift/sync-upstream.mk
@@ -77,6 +77,20 @@ sync-upstream-pr: ## Create/update PR to sync with upstream (requires gh CLI)
 		git add go.mod go.sum vendor/; \
 		git commit -m "chore: update dependencies and vendor"; \
 	fi
+	@echo "Updating toolset documentation..."
+	@$(MAKE) update-readme-tools
+	@if [ -n "$$(git status --porcelain README.md docs/configuration.md)" ]; then \
+		echo "Changes detected in toolset documentation. Committing..."; \
+		git add README.md docs/configuration.md; \
+		git commit -m "chore: update toolset documentation"; \
+	fi
+	@echo "Updating test snapshots..."
+	@$(MAKE) test-update-snapshots
+	@if [ -n "$$(git status --porcelain pkg/mcp/testdata/)" ]; then \
+		echo "Changes detected in test snapshots. Committing..."; \
+		git add pkg/mcp/testdata; \
+		git commit -m "chore: update test snapshots"; \
+	fi
 	@echo "📤 Pushing sync branch..."
 	@PUSHED_SHA=$$(git rev-parse $(SYNC_BRANCH_NAME)); \
 	git push -f $(ORIGIN_REMOTE) $(SYNC_BRANCH_NAME); \


### PR DESCRIPTION
Currently our sync misses two things:
1. Toolset doc changes between upstream and downstream
2. Test snapshot updates for downstream (e.g. due to toolset naming changes from upstream -: downstream like kiali -> ossm)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated upstream synchronization now refreshes tool documentation and test snapshots after dependency updates.
  * Generated documentation and snapshot changes are committed automatically when updates are detected.
  * These maintenance steps run before the synchronization branch is pushed and its pull request is created or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->