### PR TITLE
evals: remove hardcoded labelSelector from eval configs

### DIFF
--- a/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
@@ -15,8 +15,6 @@ config:
       path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
-      labelSelector:
-        suite: core
       assertions:
         toolsUsed:
           - server: kubernetes

--- a/evals/core-eval-testing/builtin-google/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-core.yaml
@@ -15,8 +15,6 @@ config:
       path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
-      labelSelector:
-        suite: core
       assertions:
         toolsUsed:
           - server: kubernetes


### PR DESCRIPTION
## Summary

- Removes the hardcoded `labelSelector: suite: core` from `eval-core.yaml` in both `builtin-google` and `builtin-anthropic` directories
- This makes the eval configs reusable across different suites (e.g. kubevirt) by letting the CLI `--label-selector` flag (via `EVAL_LABEL_SELECTOR` env var) be the sole filter
- Existing CI jobs already pass `EVAL_LABEL_SELECTOR=suite=core` so their behavior is unchanged

## Test plan

- [ ] Verify existing `mcpchecker-eval-google` and `mcpchecker-eval-anthropic` CI jobs still pass (they set `EVAL_LABEL_SELECTOR=suite=core`)
- [ ] Confirm new kubevirt CI jobs (added in companion release repo PR) can use the same eval configs with `EVAL_LABEL_SELECTOR=suite=kubevirt`

Ref: [CNV-94459](https://redhat.atlassian.net/browse/CNV-94459)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated core evaluation task configurations to include tasks without the previous suite label restriction.
  * Preserved existing assertions and tool-call limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->