### PR TITLE
NO-JIRA: renovate: disable python (take 2)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
   "recreateWhen": "always",
   "commitMessageSuffix": "{{baseBranch}}",
   "ignorePaths": ["Dockerfile", "/npm/**", "/docs/**", "/python/**"],
+  "packageRules": [
+    {
+      "matchCategories": ["python"],
+      "enabled": false
+    }
+  ],
   "tekton": {
     "enabled": true,
     "packageRules": [
@@ -42,12 +48,6 @@
     ]
   },
   "gomod": {
-    "enabled": false
-  },
-  "pip_requirements": {
-    "enabled": false
-  },
-  "pep621": {
     "enabled": false
   },
   "github-actions": {


### PR DESCRIPTION
Following #388, try turning off *all* python managers in renovate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated Python dependency updates.
  * Removed Python dependency managers from automated update configuration.
  * GitHub Actions update behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->