### PR TITLE
NO-JIRA: renovate: `recreateWhen: auto` for helm-values

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
     {
       "matchCategories": ["python"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["helm-values"],
+      "recreateWhen": "auto"
     }
   ],
   "tekton": {


### PR DESCRIPTION
To allow us to close bogus PRs like #426 without them being resurrected, this un-overrides the local renovate config's global `recreateWhen: "always"` just for `helm-values` managers, reverting it to the default `"auto"`. Per cache key logic, this should work as desired due to the specificity of the generated PR title.

References:
- https://docs.renovatebot.com/modules/manager/helm-values/
- https://docs.renovatebot.com/key-concepts/pull-requests/#immortal-prs

Assisted-By: claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated update handling for dependencies defined in Helm values files.
  * Updates can now be recreated automatically when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->