### PR TITLE
Mark netobserv tools as not cluster-aware

### DIFF
--- a/pkg/mcp/netobserv_test.go
+++ b/pkg/mcp/netobserv_test.go
@@ -12,6 +12,7 @@ import (
 	netobservToolset "github.com/containers/kubernetes-mcp-server/pkg/toolsets/netobserv"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type NetObservSuite struct {
@@ -123,6 +124,29 @@ func (s *NetObservSuite) TestGetFlowMetrics() {
 		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "data")
 		s.NotNil(toolResult.StructuredContent)
 	})
+}
+
+func (s *NetObservSuite) TestNetObservToolsNotClusterAware() {
+	kubeconfig := s.mockServer.Kubeconfig()
+	for i := range 10 {
+		kubeconfig.Contexts[strconv.Itoa(i)] = clientcmdapi.NewContext()
+	}
+	s.Cfg.KubeConfig = test.KubeconfigFile(s.T(), kubeconfig)
+	s.InitMcpClient()
+
+	tools, err := s.ListTools()
+	s.Require().NoError(err)
+	s.Require().NotEmpty(tools.Tools)
+
+	for _, tool := range tools.Tools {
+		s.Run(tool.Name, func() {
+			schema, ok := tool.InputSchema.(map[string]any)
+			s.Require().True(ok, "expected InputSchema map for tool %s", tool.Name)
+			properties, ok := schema["properties"].(map[string]any)
+			s.Require().True(ok, "expected properties map for tool %s", tool.Name)
+			s.NotContains(properties, "context", "netobserv tool %s must not expose context parameter", tool.Name)
+		})
+	}
 }
 
 func TestNetObservMcp(t *testing.T) {

--- a/pkg/toolsets/netobserv/toolset.go
+++ b/pkg/toolsets/netobserv/toolset.go
@@ -3,6 +3,8 @@ package netobserv
 import (
 	"slices"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/netobserv/internal/defaults"
@@ -22,11 +24,17 @@ func (t *Toolset) GetDescription() string {
 }
 
 func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
-	return slices.Concat(
+	tools := slices.Concat(
 		netobservTools.InitListFlows(),
 		netobservTools.InitGetFlowMetrics(),
 		netobservTools.InitExportFlows(),
 	)
+	// NetObserv calls a single configured console plugin endpoint; cluster scope is not
+	// selected via the provider-level context parameter injected for core Kubernetes tools.
+	for i := range tools {
+		tools[i].ClusterAware = ptr.To(false)
+	}
+	return tools
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {


### PR DESCRIPTION
## Summary

- Mark all netobserv tools as `ClusterAware: false` to prevent the MCP server from injecting a `context` parameter when multi-cluster support is enabled. NetObserv tools communicate with the console plugin backend (configured via `toolset_configs.netobserv`), not directly with the Kubernetes API, so the cluster context parameter does not apply.
- Add `TestNetObservToolsNotClusterAware` test to validate this behavior, following the same pattern as `TestKialiToolsNotClusterAware`.

## Test plan

- [x] `go test ./pkg/mcp/ -run TestNetObservMcp -v -count=1` passes
- [x] New `TestNetObservToolsNotClusterAware` verifies no netobserv tool exposes a `context` parameter when multiple clusters are configured
- [x] Existing netobserv tool tests (ListFlows, ExportFlows, GetFlowMetrics) continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NetObserv tools now consistently use the configured console endpoint instead of inheriting cluster-specific scope.
  * Removed cluster context parameters from NetObserv tool schemas, ensuring tools remain non-cluster-aware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->