### PR TITLE
OCPMCP-355: Add provisional e2e tests for prow

### DIFF
--- a/build/openshift/e2e.mk
+++ b/build/openshift/e2e.mk
@@ -1,0 +1,13 @@
+##@ OpenShift CI E2E Tests
+
+.PHONY: e2e-ci-setup
+e2e-ci-setup: helm kubectl ## Download tools needed for e2e tests (cluster is provided by ci-operator)
+
+.PHONY: e2e-ci-test
+e2e-ci-test: ## Run e2e tests against a CI-provisioned cluster
+	KUBECONFIG=$(KUBECONFIG) \
+	KUBECTL_PATH=$(KUBECTL) \
+	HELM_PATH=$(HELM) \
+	MCP_SERVER_IMAGE=$(MCP_SERVER_IMAGE) \
+	CHART_PATH=$(shell pwd)/charts/kubernetes-mcp-server \
+	go test -tags e2e -v -count=1 -timeout 20m ./test/e2e/ -run TestSmoke $(E2E_ARGS)

--- a/test/openshift/e2e-commands.sh
+++ b/test/openshift/e2e-commands.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
+
+# The ipi-aws workflow provides oc; the e2e suite expects kubectl
+if ! command -v kubectl >/dev/null 2>&1; then
+    mkdir -p /tmp/bin
+    ln -s "$(command -v oc)" /tmp/bin/kubectl
+    export PATH="/tmp/bin:${PATH}"
+fi
+
+# The test pod runs in the build-farm cluster which sets in-cluster env vars.
+# The MCP server would auto-detect these and talk to the build farm instead of
+# the IPI cluster. Unset them so it falls back to KUBECONFIG.
+unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
+
+export MCP_SERVER_IMAGE="${IMAGE_OPENSHIFT_MCP_SERVER}"
+
+make e2e-ci-setup
+make e2e-ci-test


### PR DESCRIPTION
Add provisional smoke tests, intended for testing in openshift's e2e ci environment. This will require several PRs in both this repo and openshift/release, of which this is the first. Once this PR merges, the openshift/release PR can attempt to rehearse what we have here, verifying that the machinery works. Once rehearsals are working, we can expand the tests on this side.

xref: [OCPMCP-355](https://redhat.atlassian.net/browse/OCPMCP-355)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added OpenShift end-to-end test setup and execution targets.
  * Automated preparation of Kubernetes and Helm tooling for CI test runs.
  * Added smoke testing against CI-provisioned clusters with configurable deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->