### PR TITLE
OCPMCP-355: Run the whole e2e suite

### DIFF
--- a/build/openshift/e2e.mk
+++ b/build/openshift/e2e.mk
@@ -10,4 +10,4 @@ e2e-ci-test: ## Run e2e tests against a CI-provisioned cluster
 	HELM_PATH=$(HELM) \
 	MCP_SERVER_IMAGE=$(MCP_SERVER_IMAGE) \
 	CHART_PATH=$(shell pwd)/charts/kubernetes-mcp-server \
-	go test -tags e2e -v -count=1 -timeout 20m ./test/e2e/ -run TestSmoke $(E2E_ARGS)
+	go test -tags e2e -v -count=1 -timeout 20m ./test/e2e/ $(E2E_ARGS)


### PR DESCRIPTION
Keycloak/Kuadrant tests will gracefully skip until they're added to the prow cluster (this will be ANOTHER pr in openshift/release)

xref: [OCPMCP-355](https://redhat.atlassian.net/browse/OCPMCP-355)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test execution to run the complete test suite instead of only smoke tests.
  * Retained existing timeout settings, flags, and environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->