### PR TITLE
docs: update downstream documentation for OpenShift-specific toolsets and user guide

### DIFF
--- a/docs/OSSM.md
+++ b/docs/OSSM.md
@@ -1,0 +1,58 @@
+# OpenShift Service Mesh (OSSM) Integration
+
+The OpenShift MCP Server exposes OpenShift Service Mesh (OSSM) tools (backed by Kiali) so AI assistants can query mesh topology, health, metrics, distributed traces, and manage Istio configurations.
+
+## Enable the OSSM Toolset
+
+Enable the OSSM tools via the server TOML configuration file.
+
+Config (TOML):
+
+```toml
+toolsets = ["core", "ossm"]
+
+[toolset_configs.kiali]
+url = "https://kiali.example" # Endpoint/route to reach the Kiali console
+# insecure = true  # optional: allow insecure TLS (not recommended in production)
+# certificate_authority = "/path/to/ca.crt"  # File path to CA certificate
+# When url is https and insecure is false, certificate_authority is required.
+```
+
+When the `ossm` toolset is enabled, the toolset configuration is required via `[toolset_configs.kiali]`. If missing or invalid, the server will refuse to start.
+
+## How Authentication Works
+
+- The server uses your existing Kubernetes/OpenShift credentials (from kubeconfig or in-cluster ServiceAccount) to set a bearer token for Kiali/OSSM calls.
+- If you pass an HTTP Authorization header to the MCP HTTP endpoint, that is not required for OSSM; OSSM calls use the server's configured token.
+
+## Multi-Cluster Support
+
+OSSM can manage multiple clusters within a service mesh. Most OSSM tools accept an optional `meshCluster` parameter to target a specific mesh cluster. When omitted, OSSM defaults to its home cluster (where Kiali/OSSM is deployed).
+
+Use `ossm_list_mesh_clusters` to discover available mesh cluster names before calling other tools. The `name` field from that response is the only valid value for `meshCluster`.
+
+OSSM tools are not cluster-aware via the MCP server's Kubernetes multi-cluster mechanism: the server does not inject a `context` parameter on them. Use `meshCluster` to select mesh scope. Core Kubernetes tools still use `context` when multi-cluster is enabled.
+
+## Available Tools
+
+| Tool | Description |
+| :--- | :--- |
+| `ossm_get_mesh_traffic_graph` | Returns service-to-service traffic topology, dependencies, and network metrics (throughput, response time, mTLS) for specified namespaces |
+| `ossm_get_mesh_status` | Retrieves high-level health, topology, and environment details of the Istio service mesh |
+| `ossm_get_resource_details` | Fetches lists or detailed info for mesh resources (applications, workloads, services) |
+| `ossm_get_metrics` | Returns a compact JSON summary of Istio metrics (latency quantiles, traffic trends, throughput) for a given resource |
+| `ossm_list_traces` | Lists distributed traces for a service in a namespace |
+| `ossm_get_trace_details` | Fetches a single distributed trace by trace ID and returns its call hierarchy |
+| `ossm_get_pod_performance` | Returns a human-readable summary comparing Pod CPU/memory usage to requests and limits |
+| `ossm_get_logs` | Gets logs of a Kubernetes Pod or workload in a namespace with optional severity filtering |
+| `ossm_list_mesh_clusters` | Returns the list of Istio mesh clusters accessible by Kiali/OSSM |
+| `ossm_manage_istio_config` | Creates, patches, or deletes Istio, Gateway API, and Inference API configuration objects |
+| `ossm_manage_istio_config_read` | Lists or gets Istio, Gateway API, and Inference API configuration objects (read-only) |
+
+## Troubleshooting
+
+- **Missing OSSM configuration when `ossm` toolset is enabled** → Set `[toolset_configs.kiali].url` in the config TOML.
+- **Invalid URL** → Ensure `[toolset_configs.kiali].url` is a valid `http(s)://host` URL.
+- **TLS certificate validation**:
+  - If `[toolset_configs.kiali].url` uses HTTPS and `[toolset_configs.kiali].insecure` is `false`, you must set `[toolset_configs.kiali].certificate_authority` with the path to the CA certificate file. Relative paths are resolved relative to the directory containing the config file.
+  - For non-production environments you can set `[toolset_configs.kiali].insecure = true` to skip certificate verification.

--- a/docs/openshift/README.md
+++ b/docs/openshift/README.md
@@ -4,14 +4,19 @@ This directory contains OpenShift-specific documentation for the OpenShift MCP S
 
 ## Available Guides
 
-| Guide                           | Description                                                                                           |
-|---------------------------------|-------------------------------------------------------------------------------------------------------|
-| **[ACM Support](acm.md)** | Support for ACM and notes on its environment |
-| **[NetEdge Toolset](NETEDGE.md)** | Guide for the Network Ingress & DNS troubleshooting tools |
-| **[ACM Setup](acm_setup.md)**   | Setting up Advanced Cluster Management (ACM) and using the MCP Server with multi-cluster environments |
+| Guide | Description |
+|---|---|
+| **[User Guide](user-guide.md)** | End-to-end user guide covering architecture, downstream toolsets, and security guardrails |
+| **[OpenShift Core & Prompts](../OPENSHIFT.md)** | Project management tools and `plan_mustgather` diagnostic prompt |
+| **[OpenShift Service Mesh (OSSM)](../OSSM.md)** | Service mesh management and diagnostics tools backed by Kiali |
+| **[NetEdge Toolset](NETEDGE.md)** | Network Ingress & CoreDNS troubleshooting tools |
+| **[NetEdge Validation How-To](NETEDGE-validation-how-to.md)** | Step-by-step validation guide for the NetEdge toolset |
+| **[OVN-Kubernetes Toolset](ovn-kubernetes.md)** | OVN-Kubernetes CNI network troubleshooting tools (use with [CNI Diagnostics](cni-diagnostics.md)) |
+| **[CNI Diagnostics Toolset](cni-diagnostics.md)** | Container Network Interface (CNI) diagnostics and troubleshooting |
+| **[OADP Toolset](../OADP.md)** | OpenShift API for Data Protection backup and restore tools |
+| **[ACM Support](acm.md)** | Support for Red Hat Advanced Cluster Management (ACM) multi-cluster environments |
+| **[ACM Setup](acm_setup.md)** | Setting up ACM and using the MCP Server across managed clusters |
 | **[ACM with Keycloak Setup](acm_keycloak_setup.md)** | Setting up ACM with Keycloak-based OIDC authentication for secure multi-cluster access |
-| **[OVN-Kubernetes Toolset](ovn-kubernetes.md)** | Guide for OVN-Kubernetes CNI network troubleshooting tools (use with [CNI Diagnostics](cni-diagnostics.md) for a complete toolkit) |
-| **[CNI Diagnostics Toolset](cni-diagnostics.md)** | Tools for Container Network Interface (CNI) diagnostics and troubleshooting (enable with [OVN-Kubernetes](ovn-kubernetes.md) when troubleshooting OVN-Kubernetes) |
 
 ## Overview
 

--- a/docs/openshift/user-guide.md
+++ b/docs/openshift/user-guide.md
@@ -21,10 +21,10 @@ The MCP server for Red Hat OpenShift includes several enterprise grade features
 
 ## Toolsets and Functionality
 
-By default the MCP server for Red Hat OpenShift enables only `core` and `config` tools in a read-only mode. In order to enable other available toolsets, like Kiali/OSSM or Kubevirt, those must be enabled in the `config.toml` file. In case of using `olm` or `kubevirt` toolsets there is a "config" section which needs to be updated, like:
+By default the MCP server for Red Hat OpenShift enables only `core` and `config` tools in a read-only mode. In order to enable other available toolsets, like Kiali/OSSM or Kubevirt, those must be enabled in the `config.toml` file. In case of using `ossm` or `kubevirt` toolsets there is a "config" section which needs to be updated, like:
 
 ```toml
-toolsets = ["core", "olm", "kubevirt"]
+toolsets = ["core", "ossm", "kubevirt"]
 ```
 
 ### Core
@@ -73,17 +73,23 @@ toolsets = ["core", "olm", "kubevirt"]
 | `nodes_stats_summary` | Get detailed resource usage statistics from a node via the kubelet's Summary API |
 | `nodes_top`           | List resource consumption (CPU and memory) for nodes via the Metrics Server      |
 
-### Kiali
+### OpenShift Service Mesh (OSSM)
+
+Tools for managing and diagnosing OpenShift Service Mesh (backed by Kiali). Enable via \`toolsets = ["core", "ossm"]\` and configure the \`[toolset_configs.kiali]\` section. See the [OSSM Documentation](../OSSM.md) for complete details.
 
 | Tool                           | Description                                                                                                                                                                                                  |
 | :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kiali_mesh_graph`             | Returns the topology of specific namespaces, including health, status of the mesh, and a mesh health summary overview with aggregated counts of healthy, degraded, and failing apps, workloads, and services |
-| `kiali_get_resource_details`   | Gets lists or detailed info for Kubernetes resources (services, workloads) within the service mesh                                                                                                           |
-| `kiali_get_metrics`            | Gets metrics for a specific resource (service or workload) in a namespace, with configurable duration, step, rate interval, direction, reporter, and quantiles                                               |
-| `kiali_get_traces`             | Gets distributed traces for a specific resource (app, service, or workload) in a namespace, or retrieves detailed information for a specific trace by its ID                                                 |
-| `kiali_workload_logs`          | Gets logs for a specific workload's pods in a namespace, with automatic pod and container discovery and optional filtering by container name, time range, and line count                                     |
-| `kiali_manage_istio_config`    | Creates, patches, or deletes Istio configuration objects (Gateways, VirtualServices, DestinationRules, etc.)                                                                                                 |
-| `kiali_manage_istio_config_read` | Lists or gets Istio configuration objects (Gateways, VirtualServices, etc.) in a read-only manner                                                                                                          |
+| `ossm_get_mesh_traffic_graph`  | Returns service-to-service traffic topology, dependencies, and network metrics (throughput, response time, mTLS) for specified namespaces.                                                                    |
+| `ossm_get_mesh_status`         | Retrieves high-level health, topology, and environment details of the Istio service mesh.                                                                                                                    |
+| `ossm_get_resource_details`   | Gets lists or detailed info for mesh resources (applications, workloads, services) within the service mesh.                                                                                                   |
+| `ossm_get_metrics`            | Gets metrics for a specific resource (service or workload) in a namespace, with configurable duration, step, rate interval, direction, reporter, and quantiles.                                              |
+| `ossm_list_traces`             | Lists distributed traces for a service in a namespace.                                                                                                                                                       |
+| `ossm_get_trace_details`       | Fetches a single distributed trace by trace ID and returns its call hierarchy.                                                                                                                               |
+| `ossm_get_pod_performance`     | Returns a human-readable summary comparing Pod CPU/memory usage to requests and limits.                                                                                                                      |
+| `ossm_get_logs`                | Gets logs for a specific workload's pods in a namespace, with automatic pod and container discovery and optional filtering.                                                                                |
+| `ossm_list_mesh_clusters`      | Returns the list of Istio mesh clusters accessible by Kiali/OSSM.                                                                                                                                            |
+| `ossm_manage_istio_config`     | Creates, patches, or deletes Istio, Gateway API, and Inference API configuration objects (Gateways, VirtualServices, etc.).                                                                                  |
+| `ossm_manage_istio_config_read`| Lists or gets Istio, Gateway API, and Inference API configuration objects in a read-only manner.                                                                                                              |
 
 ### Kubevirt
 
@@ -95,10 +101,20 @@ toolsets = ["core", "olm", "kubevirt"]
 
 ### Netedge
 
+Network Ingress and DNS troubleshooting tools. Enable via \`toolsets = ["core", "netedge"]\`. See the [NetEdge Documentation](NETEDGE.md) for full details.
+
 | Tool                       | Description                                                                                                                                                                                                                                                                                                                                                                          |
 | :------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `netedge_query_prometheus` | Executes specialized diagnostic queries for specific NetEdge components. Accepts a `diagnostic_target` parameter: `ingress` (error rate, active connections, reloads, top error routes), `dns` (request rate, NXDOMAIN rate, SERVFAIL rate, panic recovery, error breakdown, rewrite count), or `operators` (active firing alerts and operator up status in ingress/DNS namespaces). |
-| `get_coredns_config`       | Retrieves the current CoreDNS configuration (Corefile) from the cluster by reading the `dns-default` ConfigMap in the `openshift-dns` namespace.                                                                                                                                                                                                                                     |
+| `netedge_query_prometheus` | Executes specialized diagnostic queries for specific NetEdge components (\`ingress\`, \`dns\`, or \`operators\`).                                                                                                                                                                                                                                                                    |
+| `inspect_route`            | Inspects an OpenShift Route for configuration issues, TLS certificates, backend services, and ingress status.                                                                                                                                                                                                                                                                       |
+| `get_router_config`        | Retrieves the HAProxy router configuration (haproxy.config) from an IngressController pod.                                                                                                                                                                                                                                                                                           |
+| `get_router_info`          | Retrieves runtime info from HAProxy router pods (version, uptime, process statistics).                                                                                                                                                                                                                                                                                               |
+| `get_router_sessions`      | Retrieves active session counts and connection statistics from HAProxy router pods.                                                                                                                                                                                                                                                                                                  |
+| `get_coredns_config`       | Retrieves the current CoreDNS configuration (Corefile) from the cluster by reading the \`dns-default\` ConfigMap in the \`openshift-dns\` namespace.                                                                                                                                                                                                                                     |
+| `get_service_endpoints`    | Retrieves endpoints and endpoint slices for a service to verify backend pod availability.                                                                                                                                                                                                                                                                                            |
+| `exec_dns_in_pod`          | Executes DNS resolution commands inside an ephemeral debug pod on a specific node.                                                                                                                                                                                                                                                                                                   |
+| `probe_dns_local`          | Performs DNS lookup from the local MCP server environment.                                                                                                                                                                                                                                                                                                                           |
+| `probe_http`               | Performs HTTP/HTTPS requests to verify route and ingress endpoints.                                                                                                                                                                                                                                                                                                                   |
 
 ### Observability
 
@@ -113,6 +129,15 @@ Observability query tools are provided by [obs-mcp](https://github.com/rhobs/obs
 | `get_silences`           | `observability/metrics` | Queries silences from Alertmanager (requires `alertmanager_url`), with label matcher filtering.                                                                                                               |
 | `loki_query_range`       | `observability/logs`    | Executes a Loki LogQL range query and returns matching log streams and lines.                                                                                                                                 |
 | `tempo_search_traces`    | `observability/traces`  | Searches distributed traces in Tempo using TraceQL.                                                                                                                                                           |
+
+### Additional OpenShift Toolsets
+
+The downstream OpenShift distribution provides additional specialized toolsets:
+
+- **OpenShift Core (`openshift`)**: OpenShift project management (`projects_list`, `project_get`, etc.) and the `plan_mustgather` diagnostic prompt. See the [OpenShift Documentation](../OPENSHIFT.md).
+- **CNI Diagnostics & OVN-Kubernetes (`cni-diagnostics`, `ovn-kubernetes`)**: Comprehensive networking and OVN-Kubernetes troubleshooting tools. See the [CNI Diagnostics Guide](cni-diagnostics.md) and [OVN-Kubernetes Guide](ovn-kubernetes.md).
+- **OpenShift API for Data Protection (`oadp`)**: Backup, restore, and snapshot management tools. See the [OADP Documentation](../OADP.md).
+- **Advanced Cluster Management (`acm`)**: Multi-cluster management across OpenShift fleets. See the [ACM Support Guide](acm.md) and [ACM Setup Guide](acm_setup.md).
 
 ## Bring Your Own Model
 


### PR DESCRIPTION
### Description

As discussed and approved in #471 (per feedback from @Cali0707), this PR addresses downstream documentation gaps, broken links, and inaccuracies across OpenShift-specific documentation files (items 1, 2, and 4 from the issue):

1. **Fixes in `docs/openshift/user-guide.md`**:
   - Fixed typo referencing non-existent `olm` toolset to `ossm` (`toolsets = ["core", "ossm", "kubevirt"]`).
   - Renamed Kiali section to **OpenShift Service Mesh (OSSM)** with accurate downstream tool names (`ossm_*`) and link to OSSM documentation.
   - Completed the **NetEdge** tool listing with all 10 available tools (`inspect_route`, `get_router_config`, `exec_dns_in_pod`, etc.).
   - Added references and links to other existing downstream toolsets (`openshift`, `cni-diagnostics`, `ovn-kubernetes`, `oadp`, `acm`).
   - *(Note: Toolsets currently in design/finalization like `mustgather` and `cluster-diagnostics` have been intentionally excluded per maintainer feedback).*

2. **Added `docs/OSSM.md`**:
   - Created the dedicated OpenShift Service Mesh guide documenting the `ossm` toolset, configuration (`[toolset_configs.kiali]`), multi-cluster `meshCluster` parameter, and full tool catalog.
   - Resolves the broken link referenced in `pkg/toolsets/kiali/internal/defaults/defaults_override.go`.
   - Leaves upstream's `docs/KIALI.md` completely intact to avoid sync conflicts.

3. **Updated Index in `docs/openshift/README.md`**:
   - Updated the table of available guides to index all downstream documentation (`user-guide.md`, `OSSM.md`, `OPENSHIFT.md`, `NETEDGE.md`, `NETEDGE-validation-how-to.md`, `ovn-kubernetes.md`, `cni-diagnostics.md`, `OADP.md`, `acm.md`, `acm_setup.md`, `acm_keycloak_setup.md`).
   - Verified that all internal markdown links are valid.

### Related Issue

Fixes #471 (Items 1, 2, and 4)

### Verification

- [x] All internal relative markdown links verified and resolve properly.
- [x] Verified zero modifications to upstream-tracked files (all changes are strictly downstream).
- [x] DCO Signed-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring and using OpenShift Service Mesh tools, including authentication, multi-cluster targeting, available tools, and troubleshooting.
  - Updated the OpenShift documentation index with expanded guide listings and descriptions.
  - Updated user guide examples and toolset documentation, including additional NetEdge diagnostics and downstream OpenShift toolsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->